### PR TITLE
Fix gem info showing up for spectators

### DIFF
--- a/Libraries/UILibraries2.php
+++ b/Libraries/UILibraries2.php
@@ -120,7 +120,7 @@ function JSONRenderedCard(
     'restriction' => $restriction,
     'isBroken' => $isBroken,
     'onChain' => $onChain,
-    'isFrozen' => $isFrozen,,
+    'isFrozen' => $isFrozen,
     'gem' => $gem,
     'countersMap' => $countersMap,
     'label' => $label,

--- a/Libraries/UILibraries2.php
+++ b/Libraries/UILibraries2.php
@@ -102,6 +102,8 @@ function JSONRenderedCard(
     return !is_null($val);
   });
 
+  if(!$isSpectator) $gem = 0;
+
   $card = (object) [
     'cardNumber' => $cardNumber,
     'action' => $action,
@@ -118,11 +120,11 @@ function JSONRenderedCard(
     'restriction' => $restriction,
     'isBroken' => $isBroken,
     'onChain' => $onChain,
-    'isFrozen' => $isFrozen,
+    'isFrozen' => $isFrozen,,
+    'gem' => $gem,
     'countersMap' => $countersMap,
     'label' => $label,
   ];
-  if(!$isSpectator) $card->gem = $gem;
 
   // To reduce space/size strip out all values that are null.
   // On the FE repopulate the null values with the defaults like the binary blob.

--- a/Libraries/UILibraries2.php
+++ b/Libraries/UILibraries2.php
@@ -69,6 +69,8 @@ function JSONRenderedCard(
   $countersMap = new stdClass(), // new object for counters
   $label = NULL
 ) {
+  global $playerID;
+  $isSpectator = (isset($playerID) && intval($playerID) == 3 ? true : false);
 
   $countersMap->counters = property_exists($countersMap, 'counters') ?
     $countersMap->counters : $counters;
@@ -117,10 +119,10 @@ function JSONRenderedCard(
     'isBroken' => $isBroken,
     'onChain' => $onChain,
     'isFrozen' => $isFrozen,
-    'gem' => $gem,
     'countersMap' => $countersMap,
     'label' => $label,
   ];
+  if(!$isSpectator) $card->gem = $gem;
 
   // To reduce space/size strip out all values that are null.
   // On the FE repopulate the null values with the defaults like the binary blob.


### PR DESCRIPTION
Issue: Gems showing up for spectators
Fix: Make the gem return 0 always for spectators
Alternatives considered:
1. Send back null -> did not do this so we don't need to add special handling
2. Omit property entirely -> did not do this so we don't need to add special handling