### PR TITLE
React add api for game stats

### DIFF
--- a/GetPopupAPI.php
+++ b/GetPopupAPI.php
@@ -71,8 +71,8 @@ switch ($popupType) {
     JSONPopup($response, $myDeck, DeckPieces());
     break;
   case "myStatsPopup":
-    //TODO
-    //echo (CreatePopup("myStatsPopup", [], 1, 0, "Your Game Stats", 1, CardStats($playerID), "./", true));
+    echo(SerializeGameResult($playerID, "", file_get_contents("./Games/" . $gameName . "/p" . $playerID . "Deck.txt"), $gameName));
+    exit;
     break;
   case "menuPopup":
     /*

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -436,6 +436,8 @@ function SendFullFabraryResults($gameID, $p1Decklink, $p1Deck, $p1Hero, $p1deckb
 function SerializeGameResult($player, $DeckLink, $deckAfterSB, $gameID="", $opposingHero="", $gameName="", $deckbuilderID="")
 {
 	global $winner, $currentTurn, $CardStats_TimesPlayed, $CardStats_TimesBlocked, $CardStats_TimesPitched, $firstPlayer;
+	global $TurnStats_DamageThreatened, $TurnStats_DamageDealt, $TurnStats_CardsPlayedOffense, $TurnStats_CardsPlayedDefense, $TurnStats_CardsPitched, $TurnStats_CardsBlocked;
+	global $TurnStats_ResourcesUsed, $TurnStats_CardsLeft, $TurnStats_DamageBlocked;
 	$DeckLink = explode("/", $DeckLink);
 	$DeckLink = $DeckLink[count($DeckLink)-1];
 	$deckAfterSB = explode("\r\n", $deckAfterSB);
@@ -479,6 +481,17 @@ function SerializeGameResult($player, $DeckLink, $deckAfterSB, $gameID="", $oppo
 				break;
 			}
 		}
+	}
+	$turnStats = &GetTurnStats($player);
+	$otherPlayerTurnStats = &GetTurnStats(($player == 1 ? 2 : 1));
+	for ($i = 0; $i < count($turnStats); $i += TurnStatPieces()) {
+		$deck["turnResults"][$i]["cardsUsed"] = ($turnStats[$i + $TurnStats_CardsPlayedOffense] + $turnStats[$i + $TurnStats_CardsPlayedDefense]);
+		$deck["turnResults"][$i]["cardsBlocked"] = $turnStats[$i + $TurnStats_CardsBlocked];
+		$deck["turnResults"][$i]["cardsPitched"] = $turnStats[$i + $TurnStats_CardsPitched];
+		$deck["turnResults"][$i]["resourcesUsed"] = $turnStats[$i + $TurnStats_ResourcesUsed];
+		$deck["turnResults"][$i]["cardsLeft"] = $turnStats[$i + $TurnStats_CardsLeft];
+		$deck["turnResults"][$i]["damageDealt"] = $turnStats[$i + $TurnStats_DamageDealt];
+		$deck["turnResults"][$i]["damageTaken"] = $otherPlayerTurnStats[$i + $TurnStats_DamageDealt];
 	}
 	return json_encode($deck);
 }


### PR DESCRIPTION
Create API for game stats
Note this uses a keyed array JSON structure instead of an object based JSON structure. This was done to keep it consistent with how the data is sent to fabrary and fabdb. A side effect of this pull request is additional data will be sent to fabrary and fabdb (the turn stats e.g. how much damage was threatened each turn).