### PR TITLE
Weapon/Equipment Support (Take 2)

### DIFF
--- a/Roguelike/EncounterDictionary.php
+++ b/Roguelike/EncounterDictionary.php
@@ -122,6 +122,19 @@ function GetRandomCards($number)
   return $rv;
 }
 
+function RandomDoriRare(){
+  //Notable Exclusions: Dauntless RYB, Precision Press RYB
+  $DoriPoolRandomRare = array(
+    "WTR123", "WTR124", "WTR125", "WTR126", "WTR127", "WTR128", "WTR129", "WTR130", "WTR131",
+    "MON110", "MON111", "MON112", "MON113", "MON114", "MON115",
+    "DVR013", 
+    "EVR057", "EVR058", "EVR059",
+    "DYN073", "DYN074", "DYN075"
+  );
+  $poolCount = count($DoriPoolRandomRare);
+  $number = rand(0, $poolCount - 1);
+  return $DoriPoolRandomRare[$number];
+}
 function RandomDoriCommon()
 {
   //Card pool is all warrior commons up to Everfest, except Outland Skirmish
@@ -138,7 +151,6 @@ function RandomDoriCommon()
 
 function RandomGenericCommon()
 {
-  //Wounding Blow RYB, Brandish RYB, Ravenous Rabble RYB
   $GenericPoolCommon = array(
     "WTR203", "WTR204", "WTR205", "WTR212", "WTR213", "WTR214", 
     "ARC182", "ARC183", "ARC184", "ARC191", "ARC192", "ARC193",

--- a/Roguelike/InitializeGame.php
+++ b/Roguelike/InitializeGame.php
@@ -14,7 +14,7 @@
     $health = &GetZone($i, "Health");
     array_push($health, 20);//TODO: Base on hero health
     $character = &GetZone($i, "Character");
-    $character = explode(" ", "DVR001 DVR002 WTR156 WTR157 WTR158 CRU177");//TODO: Support multiple heroes
+    $character = explode(" ", "DVR001 DVR002 WTR156");//TODO: Support multiple heroes
     $deck = &GetZone($i, "Deck");
     $deck = explode(" ", "WTR129 WTR145 WTR201 ARC205 CRU093 MON116 MON283 DVR019 DVR022 DVR009 DVR024 CRU186");//TODO: Support multiple heroes
     $encounter = &GetZone($i, "Encounter");

--- a/Roguelike/InitializeGame.php
+++ b/Roguelike/InitializeGame.php
@@ -14,7 +14,7 @@
     $health = &GetZone($i, "Health");
     array_push($health, 20);//TODO: Base on hero health
     $character = &GetZone($i, "Character");
-    $character = explode(" ", "DVR001 DVR002 WTR156");//TODO: Support multiple heroes
+    $character = explode(" ", "DVR001 DVR002 WTR156 WTR157 WTR158 CRU177");//TODO: Support multiple heroes
     $deck = &GetZone($i, "Deck");
     $deck = explode(" ", "WTR129 WTR145 WTR201 ARC205 CRU093 MON116 MON283 DVR019 DVR022 DVR009 DVR024 CRU186");//TODO: Support multiple heroes
     $encounter = &GetZone($i, "Encounter");

--- a/Roguelike/PlayEncounter.php
+++ b/Roguelike/PlayEncounter.php
@@ -46,8 +46,13 @@ for ($i = 1; $i < count($charZone); ++$i) {
       //We don't need to process equipment here, instead we look for relevant Subtypes
       break;
     case "W":
-      if ($weapon1 == "") $weapon1 = $charZone[$i];
-      else {
+      if ($weapon1 == "") { //If this is the first weapon read on the file,
+        $weapon1 = $charZone[$i]; // then equip it
+      }
+      elseif(is1H($weapon1) && is1H($charZone[$i])) { //If equipped and current are both 1h,
+        $weapon2 = $charZone[$i];                    // then Equip the new one in second hand
+      }
+      else { //If we have extra weapons, then sideboard them
         $weaponSideboard .= $charZone[$i];
       }
       break;

--- a/Roguelike/PlayEncounter.php
+++ b/Roguelike/PlayEncounter.php
@@ -1,96 +1,148 @@
-
 <?php
 
-  include '../Libraries/HTTPLibraries.php';
+include '../Libraries/HTTPLibraries.php';
 
-  //We should always have a player ID as a URL parameter
-  $gameName=$_GET["gameName"];
-  $playerID=TryGet("playerID", 3);
-  $hero=TryGet("hero", "");
+//We should always have a player ID as a URL parameter
+$gameName = $_GET["gameName"];
+$playerID = TryGet("playerID", 3);
+$hero = TryGet("hero", "");
 
-  //First we need to parse the game state from the file
-  include "ZoneGetters.php";
-  include "ParseGamestate.php";
-  include "../HostFiles/Redirector.php";
-  include "../CardDictionary.php";
+//First we need to parse the game state from the file
+include "ZoneGetters.php";
+include "ParseGamestate.php";
+include "../HostFiles/Redirector.php";
+include "../CardDictionary.php";
 
-  $charZone = &GetZone($playerID, "Character");
-  $cards = &GetZone($playerID, "Deck");
-  $encounter = &GetZone($playerID, "Encounter");
-  $health = &GetZone($playerID, "Health");
+$charZone = & GetZone($playerID, "Character");
+$cards = & GetZone($playerID, "Deck");
+$encounter = & GetZone($playerID, "Encounter");
+$health = & GetZone($playerID, "Health");
 
-  $deckCards = "";
-  $sideboardCards = "";
-  $headSideboard = ""; $chestSideboard = ""; $armsSideboard = ""; $legsSideboard = ""; $offhandSideboard = "";
-  $unsupportedCards = "";
-  $character = ""; $head = ""; $chest = ""; $arms = ""; $legs = ""; $offhand = "";
-  $weapon1 = "";
-  $weapon2 = "";
-  $weaponSideboard = "";
-  $character = $charZone[0];
-  $weapon1 = $charZone[1];
-  $deckCards = implode(" ", $cards);
+$deckCards = "";
+$sideboardCards = "";
+$headSideboard = "";
+$chestSideboard = "";
+$armsSideboard = "";
+$legsSideboard = "";
+$offhandSideboard = "";
+$unsupportedCards = "";
+$character = "";
+$head = "";
+$chest = "";
+$arms = "";
+$legs = "";
+$offhand = "";
+$weapon1 = "";
+$weapon2 = "";
+$weaponSideboard = "";
+$character = $charZone[0];
+//$weapon1 = $charZone[1];
+$deckCards = implode(" ", $cards);
 
-  for($i=1; $i<count($charZone); ++$i)
-  {
-    $subtype = CardSubType($charZone[$i]);
-    switch($subtype)
-    {
-      case "Head":
-        if($head == "") $head = $charZone[$i];
-        else
-        {
-          if($headSideboard != "") $headSideboard .= " ";
-          $headSideboard .= $charZone[$i];
-        }
-        break;
-      case "Chest":
-        if($chest == "") $chest = $charZone[$i];
-        else
-        {
-          if($chestSideboard != "") $chestSideboard .= " ";
-          $chestSideboard .= $charZone[$i];
-        }
-        break;  
-      default: break;
-    }
+for ($i = 1; $i < count($charZone); ++$i) {
+  $type = CardType($charZone[$i]);
+  switch ($type) {
+    case "E":
+      //We don't need to process equipment here, instead we look for relevant Subtypes
+      break;
+    case "W":
+      if ($weapon1 == "") $weapon1 = $charZone[$i];
+      else {
+        $weaponSideboard .= $charZone[$i];
+      }
+      break;
+    default:
+      break;
   }
-
-    $filename = "./Games/" . $gameName . "/LimitedDeck.txt";
-    $deckFile = fopen($filename, "w");
-    $charString = $character;
-    if($weapon1 != "") $charString .= " " . $weapon1;
-    if($weapon2 != "") $charString .= " " . $weapon2;
-    if($offhand != "") $charString .= " " . $offhand;
-    if($head != "") $charString .= " " . $head;
-    if($chest != "") $charString .= " " . $chest;
-    if($arms != "") $charString .= " " . $arms;
-    if($legs != "") $charString .= " " . $legs;
-    fwrite($deckFile, $charString . "\r\n");
-    fwrite($deckFile, $deckCards . "\r\n");
-    fwrite($deckFile, $headSideboard . "\r\n");
-    fwrite($deckFile, $chestSideboard . "\r\n");
-    fwrite($deckFile, $armsSideboard . "\r\n");
-    fwrite($deckFile, $legsSideboard . "\r\n");
-    fwrite($deckFile, $offhandSideboard . "\r\n");
-    fwrite($deckFile, $weaponSideboard . "\r\n");
-    fwrite($deckFile, $sideboardCards);
-    fclose($deckFile);
-
-  $encounterName = GetEncounterName($encounter[0]);
-
-  header("Location: " . $redirectPath . "/CreateGame.php?deckTestMode=" . $encounterName . "&roguelikeGameID=" . $gameName . "&deck=ROGUELIKE-" . $gameName. "&startingHealth=" . $health[0]);
-
-  function GetEncounterName($encounterId)
-  {
-    switch($encounterId)
-    {
-      case 1: return "Woottonhog";
-      case 3: return "RavenousRabble";
-      case 5: return "BarragingBrawnhide";
-      case 7: return "ShockStriker";
-      default: return "Woottonhog";
-    }
+  $subtype = CardSubType($charZone[$i]);
+  switch ($subtype) {
+    case "Head":
+      if ($head == "")
+        $head = $charZone[$i];
+      else {
+        if ($headSideboard != "")
+          $headSideboard .= " ";
+        $headSideboard .= $charZone[$i];
+      }
+      break;
+    case "Chest":
+      if ($chest == "")
+        $chest = $charZone[$i];
+      else {
+        if ($chestSideboard != "")
+          $chestSideboard .= " ";
+        $chestSideboard .= $charZone[$i];
+      }
+      break;
+    case "Arms":
+      if ($arms == "")
+        $arms = $charZone[$i];
+      else {
+        if ($armsSideboard != "")
+          $armsSideboard .= " ";
+        $armsSideboard .= $charZone[$i];
+      }
+      break;
+    case "Legs":
+      if ($legs == "")
+        $legs = $charZone[$i];
+      else {
+        if ($legsSideboard != "")
+          $legsSideboard .= " ";
+        $legsSideboard .= $charZone[$i];
+      }
+      break;
+    default:
+      break;
   }
+}
+
+$filename = "./Games/" . $gameName . "/LimitedDeck.txt";
+$deckFile = fopen($filename, "w");
+$charString = $character;
+if ($weapon1 != "")
+  $charString .= " " . $weapon1;
+if ($weapon2 != "")
+  $charString .= " " . $weapon2;
+if ($offhand != "")
+  $charString .= " " . $offhand;
+if ($head != "")
+  $charString .= " " . $head;
+if ($chest != "")
+  $charString .= " " . $chest;
+if ($arms != "")
+  $charString .= " " . $arms;
+if ($legs != "")
+  $charString .= " " . $legs;
+fwrite($deckFile, $charString . "\r\n");
+fwrite($deckFile, $deckCards . "\r\n");
+fwrite($deckFile, $headSideboard . "\r\n");
+fwrite($deckFile, $chestSideboard . "\r\n");
+fwrite($deckFile, $armsSideboard . "\r\n");
+fwrite($deckFile, $legsSideboard . "\r\n");
+fwrite($deckFile, $offhandSideboard . "\r\n");
+fwrite($deckFile, $weaponSideboard . "\r\n");
+fwrite($deckFile, $sideboardCards);
+fclose($deckFile);
+
+$encounterName = GetEncounterName($encounter[0]);
+
+header("Location: " . $redirectPath . "/CreateGame.php?deckTestMode=" . $encounterName . "&roguelikeGameID=" . $gameName . "&deck=ROGUELIKE-" . $gameName . "&startingHealth=" . $health[0]);
+
+function GetEncounterName($encounterId)
+{
+  switch ($encounterId) {
+    case 1:
+      return "Woottonhog";
+    case 3:
+      return "RavenousRabble";
+    case 5:
+      return "BarragingBrawnhide";
+    case 7:
+      return "ShockStriker";
+    default:
+      return "Woottonhog";
+  }
+}
 
 ?>

--- a/Roguelike/PlayEncounter.php
+++ b/Roguelike/PlayEncounter.php
@@ -36,7 +36,7 @@ $weapon1 = "";
 $weapon2 = "";
 $weaponSideboard = "";
 $character = $charZone[0];
-//$weapon1 = $charZone[1];
+//$weapon1 = $charZone[1]; //Old code
 $deckCards = implode(" ", $cards);
 
 for ($i = 1; $i < count($charZone); ++$i) {
@@ -50,9 +50,16 @@ for ($i = 1; $i < count($charZone); ++$i) {
         $weapon1 = $charZone[$i]; // then equip it
       }
       elseif(is1H($weapon1) && is1H($charZone[$i])) { //If equipped and current are both 1h,
-        $weapon2 = $charZone[$i];                    // then Equip the new one in second hand
+        if($weapon2 == "" && $offhand == "") $weapon2 = $charZone[$i];
+        else {
+          if ($weaponSideboard != "")
+          $weaponSideboard .= " ";
+        $weaponSideboard .= $charZone[$i];
+        }
       }
       else { //If we have extra weapons, then sideboard them
+        if ($weaponSideboard != "")
+          $weaponSideboard .= " ";
         $weaponSideboard .= $charZone[$i];
       }
       break;
@@ -97,6 +104,14 @@ for ($i = 1; $i < count($charZone); ++$i) {
         $legsSideboard .= $charZone[$i];
       }
       break;
+    case "Off-Hand":
+      if ($offhand == "")
+        $offhand = $charZone[$i];
+        else {
+        if ($offhandSideboard != "")
+          $offhandSideboard .= " ";
+        $offhandSideboard .= $charZone[$i];
+        }
     default:
       break;
   }

--- a/Roguelike/ProcessInput.php
+++ b/Roguelike/ProcessInput.php
@@ -49,7 +49,7 @@
           unset($options[$found]);
           $options = array_values($options);
         }
-        if(CardType($cardID) == "E")
+        if(CardType($cardID) == "E" || CardType($cardID) == "W")
         {
           $char = &GetZone($playerID, "Character");
           array_push($char, $cardID);


### PR DESCRIPTION
This change allows weapons, offhand, and all equipments to be added to the character's deck either at the very beginning of through card rewards. It also allows multiple 1H weapons to be equipped by default.

I also added a pool of rare warrior cards to potentially be given out as card rewards, though they are as of yet unused.

Forgive the messy change comparison, I clicked "format file" in GitHub so it removed a spaces from the beginning of each line.

Sorry for having to make this twice!