### PR TITLE
Delete redirects causing problems for react FE

### DIFF
--- a/APIs/SubmitSideboard.php
+++ b/APIs/SubmitSideboard.php
@@ -50,8 +50,6 @@ fclose($deckFile);
 
 if ($playerID == 2) {
   $gameStatus = $MGS_ReadyToStart;
-} else {
-  $gameStatus = $MGS_GameStarted;
 }
 
 $response->status = "OK";

--- a/APIs/SubmitSideboard.php
+++ b/APIs/SubmitSideboard.php
@@ -1,7 +1,18 @@
 <?php
 
+include "../HostFiles/Redirector.php";
 include "../Libraries/HTTPLibraries.php";
 include "../Libraries/SHMOPLibraries.php";
+include "../Libraries/NetworkingLibraries.php";
+include "../GameLogic.php";
+include "../GameTerms.php";
+include "../Libraries/StatFunctions.php";
+include "../Libraries/PlayerSettings.php";
+include "../Libraries/UILibraries2.php";
+include "../AI/CombatDummy.php";
+include_once "../includes/dbh.inc.php";
+include_once "../includes/functions.inc.php";
+include_once "../MenuFiles/StartHelper.php";
 
 SetHeaders();
 
@@ -50,6 +61,89 @@ fclose($deckFile);
 
 if ($playerID == 2) {
   $gameStatus = $MGS_ReadyToStart;
+}
+else {
+
+
+  //First initialize the initial state of the game
+  $filename = "../Games/" . $gameName . "/gamestate.txt";
+  $handler = fopen($filename, "w");
+  fwrite($handler, "20 20\r\n"); //Player health totals
+
+  //Player 1
+  $p1DeckHandler = fopen("../Games/" . $gameName . "/p1Deck.txt", "r");
+  initializePlayerState($handler, $p1DeckHandler, 1);
+  fclose($p1DeckHandler);
+
+  //Player 2
+  $p2DeckHandler = fopen("../Games/" . $gameName . "/p2Deck.txt", "r");
+  initializePlayerState($handler, $p2DeckHandler, 2);
+  fclose($p2DeckHandler);
+
+  fwrite($handler, "\r\n"); //Landmarks
+  fwrite($handler, "0\r\n"); //Game winner (0=none, else player ID)
+  fwrite($handler, "$firstPlayer\r\n"); //First Player
+  fwrite($handler, "1\r\n"); //Current Player
+  fwrite($handler, "1\r\n"); //Current Turn
+  fwrite($handler, "M 1\r\n"); //What phase/player is active
+  fwrite($handler, "1\r\n"); //Action points
+  fwrite($handler, "\r\n"); //Combat Chain
+  fwrite($handler, "0 0 NA 0 0 0 0 GY NA 0 0 0 0 0 0 0 NA 0 0 -1 -1 NA 0 0 0 -1 0 0 0 0 - 0 0 0\r\n"); //Combat Chain State
+  fwrite($handler, "\r\n"); //Current Turn Effects
+  fwrite($handler, "\r\n"); //Current Turn Effects From Combat
+  fwrite($handler, "\r\n"); //Next Turn Effects
+  fwrite($handler, "\r\n"); //Decision Queue
+  fwrite($handler, "0\r\n"); //Decision Queue Variables
+  fwrite($handler, "0 - - -\r\n"); //Decision Queue State
+  fwrite($handler, "\r\n"); //Layers
+  fwrite($handler, "\r\n"); //Layer Priority
+  fwrite($handler, "1\r\n"); //What player's turn it is
+  fwrite($handler, "\r\n"); //Last Played Card
+  fwrite($handler, "0\r\n"); //Number of prior chain links this turn
+  fwrite($handler, "\r\n"); //Chain Link Summaries
+  fwrite($handler, $p1Key . "\r\n"); //Player 1 auth key
+  fwrite($handler, $p2Key . "\r\n"); //Player 2 auth key
+  fwrite($handler, 0 . "\r\n"); //Permanent unique ID counter
+  fwrite($handler, "0\r\n"); //Game status -- 0 = START, 1 = PLAY, 2 = OVER
+  fwrite($handler, "\r\n"); //Animations
+  fwrite($handler, "0\r\n"); //Current Player activity status -- 0 = active, 2 = inactive
+  fwrite($handler, "0\r\n"); //Player1 Rating - 0 = not rated, 1 = green (positive), 2 = red (negative)
+  fwrite($handler, "0\r\n"); //Player2 Rating - 0 = not rated, 1 = green (positive), 2 = red (negative)
+  fwrite($handler, "0\r\n"); //Player 1 total time
+  fwrite($handler, "0\r\n"); //Player 2 total time
+  fwrite($handler, time() . "\r\n"); //Last update time
+  fwrite($handler, $roguelikeGameID . "\r\n"); //Last update time
+  fclose($handler);
+
+  //Set up log file
+  $filename = "../Games/" . $gameName . "/gamelog.txt";
+  $handler = fopen($filename, "w");
+  fclose($handler);
+
+  $currentTime = strval(round(microtime(true) * 1000));
+  $currentUpdate = GetCachePiece($gameName, 1);
+  $p1Hero = GetCachePiece($gameName, 7);
+  $p2Hero = GetCachePiece($gameName, 8);
+  $currentPlayer = 0;
+  $isReplay = 0;
+  WriteCache($gameName, ($currentUpdate + 1) . "!" . $currentTime . "!" . $currentTime . "!-1!-1!" . $currentTime . "!"  . $p1Hero . "!" . $p2Hero . "!" . $currentPlayer . "!" . $isReplay . "!0!0"); //Initialize SHMOP cache for this game
+
+/*
+  $gameStateTries = 0;
+  while (!file_exists($filename) && $gameStateTries < 10) {
+    usleep(100000); //100ms
+    ++$gameStateTries;
+  }
+*/
+  ob_start();
+  $filename = "../Games/" . $gameName . "/gamestate.txt";
+  include "../ParseGamestate.php";
+  include "../StartEffects.php";
+  ob_end_clean();
+
+  //Update the game file to show that the game has started and other players can join to spectate
+  $gameStatus = $MGS_GameStarted;
+
 }
 
 $response->status = "OK";

--- a/GetNextTurn3.php
+++ b/GetNextTurn3.php
@@ -74,7 +74,7 @@ while ($lastUpdate != 0 && $cacheVal <= $lastUpdate) {
       $opponentDisconnected = true;
     }
     //Handle server timeout
-    $lastUpdateTime = $cacheArr[5];
+    $lastUpdateTime = GetCachePiece($gameName, 6);
     if ($currentTime - $lastUpdateTime > 90000 && GetCachePiece($gameName, 12) != "1")//90 seconds
     {
       SetCachePiece($gameName, 12, "1");

--- a/MenuFiles/StartHelper.php
+++ b/MenuFiles/StartHelper.php
@@ -1,0 +1,104 @@
+<?php
+
+function initializePlayerState($handler, $deckHandler, $player)
+{
+  global $p1IsPatron, $p2IsPatron, $p1IsChallengeActive, $p2IsChallengeActive, $p1id, $p2id;
+  global $SET_AlwaysHoldPriority, $SET_TryUI2, $SET_DarkMode, $SET_ManualMode, $SET_SkipARs, $SET_SkipDRs, $SET_PassDRStep, $SET_AutotargetArcane;
+  global $SET_ColorblindMode, $SET_EnableDynamicScaling, $SET_Mute, $SET_Cardback, $SET_IsPatron;
+  global $SET_MuteChat, $SET_DisableStats, $SET_CasterMode, $SET_Language;
+  $charEquip = GetArray($deckHandler);
+  $deckCards = GetArray($deckHandler);
+  $deckSize = count($deckCards);
+  fwrite($handler, "\r\n"); //Hand
+
+  if($player == 1) $p1IsChallengeActive = "0";
+  else if($player == 2) $p2IsChallengeActive = "0";
+
+  //Equipment challenge
+  /*
+  if($charEquip[0] != "ARC001" && $charEquip[0] != "ARC002" && $charEquip[1] == "CRU177")
+  {
+    if($player == 1) $p1IsChallengeActive = "1";
+    else if($player == 2) $p2IsChallengeActive = "1";
+  }
+  */
+/*
+  $challengeThreshold = (CharacterHealth($charEquip[0]) > 25 ? 6 : 4);
+  $numChallengeCard = 0;
+  for($i=0; $i<count($deckCards); ++$i)
+  {
+    if($deckCards[$i] == "ARC185") ++$numChallengeCard;
+    if($deckCards[$i] == "ARC186") ++$numChallengeCard;
+    if($deckCards[$i] == "ARC187") ++$numChallengeCard;
+  }
+  if($player == 1 && $numChallengeCard >= $challengeThreshold) $p1IsChallengeActive = "1";
+  else if($player == 2 && $numChallengeCard >= $challengeThreshold) $p2IsChallengeActive = "1";
+*/
+  fwrite($handler, implode(" ", $deckCards) . "\r\n");
+
+  for ($i = 0; $i < count($charEquip); ++$i) {
+    fwrite($handler, $charEquip[$i] . " 2 0 0 0 " . CharacterNumUsesPerTurn($charEquip[$i]) . " 0 0 0 " . CharacterDefaultActiveState($charEquip[$i]) . ($i < count($charEquip) - 1 ? " " : "\r\n"));
+  }
+  //Character and equipment. First is ID. Four numbers each. First is status (0=Destroy/unavailable, 1=Used, 2=Unused, 3=Disabled). Second is num counters
+  //Third is attack modifier, fourth is block modifier
+  //Order: Character, weapon 1, weapon 2, head, chest, arms, legs
+  fwrite($handler, "0 0\r\n"); //Resources float/needed
+  fwrite($handler, "\r\n"); //Arsenal
+  fwrite($handler, "\r\n"); //Item
+  fwrite($handler, "\r\n"); //Aura
+  fwrite($handler, "\r\n"); //Discard
+  fwrite($handler, "\r\n"); //Pitch
+  fwrite($handler, "\r\n"); //Banish
+  fwrite($handler, "0 0 0 0 0 0 0 0 DOWN 0 -1 0 0 0 0 0 0 -1 0 0 0 0 NA 0 0 0 - -1 0 0 0 0 0 0 - 0 0 0 0 0 0 - 0 - - 0 -1 0 0 0 0 0 - 0 0 0 0 0 -1 0 - 0 0 - 0 0\r\n"); //Class State
+  fwrite($handler, "\r\n"); //Character effects
+  fwrite($handler, "\r\n"); //Soul
+  fwrite($handler, "\r\n"); //Card Stats
+  fwrite($handler, "\r\n"); //Turn Stats
+  fwrite($handler, "\r\n"); //Allies
+  fwrite($handler, "\r\n"); //Permanents
+  $holdPriority = "0"; //Auto-pass layers
+  $isPatron = ($player == 1 ? $p1IsPatron : $p2IsPatron);
+  if($isPatron == "") $isPatron = "0";
+  $mute = 0;
+  $userId = ($player == 1 ? $p1id : $p2id);
+  $savedSettings = LoadSavedSettings($userId);
+  $settingArray = [];
+  for($i=0; $i<=22; ++$i)
+  {
+    $value = "";
+    switch($i)
+    {
+      case $SET_Mute: $value = $mute; break;
+      case $SET_IsPatron: $value = $isPatron; break;
+      default: $value = SettingDefaultValue($i); break;
+    }
+    array_push($settingArray, $value);
+  }
+  for($i=0; $i<count($savedSettings); $i+=2)
+  {
+    $settingArray[$savedSettings[intval($i)]] = $savedSettings[intval($i)+1];
+  }
+  fwrite($handler, implode(" ", $settingArray) . "\r\n"); //Settings
+}
+
+function SettingDefaultValue($setting)
+{
+  global $SET_AlwaysHoldPriority, $SET_TryUI2, $SET_DarkMode, $SET_ManualMode, $SET_SkipARs, $SET_SkipDRs, $SET_PassDRStep, $SET_AutotargetArcane;
+  global $SET_ColorblindMode, $SET_EnableDynamicScaling, $SET_Mute, $SET_Cardback, $SET_IsPatron;
+  global $SET_MuteChat, $SET_DisableStats, $SET_CasterMode, $SET_Language;
+  switch($setting)
+  {
+    case $SET_TryUI2: return "1";
+    case $SET_AutotargetArcane: return "1";
+    default: return "0";
+  }
+}
+
+function GetArray($handler)
+{
+  $line = trim(fgets($handler));
+  if ($line == "") return [];
+  return explode(" ", $line);
+}
+
+?>

--- a/ParseGamestate.php
+++ b/ParseGamestate.php
@@ -7,7 +7,7 @@ function GetStringArray($line)
   return explode(" ", $line);
 }
 
-
+if(!isset($filename) || !str_contains($filename, "gamestate.txt")) $filename = "./Games/" . $gameName . "/gamestate.txt";
 
 ParseGamestate();
 
@@ -23,13 +23,11 @@ function ParseGamestate($useRedis = false)
   global $layers, $layerPriority, $mainPlayer, $defPlayer, $lastPlayed, $chainLinks, $chainLinkSummary, $p1Key, $p2Key;
   global $permanentUniqueIDCounter, $inGameStatus, $animations, $currentPlayerActivity, $p1PlayerRating, $p2PlayerRating;
   global $p1TotalTime, $p2TotalTime, $lastUpdateTime, $roguelikeGameID, $events, $lastUpdate;
-  global $mainPlayerGamestateStillBuilt, $mpgBuiltFor, $myStateBuiltFor, $playerID;
+  global $mainPlayerGamestateStillBuilt, $mpgBuiltFor, $myStateBuiltFor, $playerID, $filename;
 
   $mainPlayerGamestateStillBuilt = 0;
   $mpgBuiltFor = -1;
   $myStateBuiltFor = -1;
-
-  $filename = "./Games/" . $gameName . "/gamestate.txt";
 
   $fileTries = 0;
   $targetTries = ($playerID == 1 ? 10 : 100);

--- a/ParseGamestate.php
+++ b/ParseGamestate.php
@@ -32,33 +32,16 @@ function ParseGamestate($useRedis = false)
   $filename = "./Games/" . $gameName . "/gamestate.txt";
 
   $fileTries = 0;
-  $targetTries = ($playerID == 1 ? 5 : 100);
-  $waitTime = ($playerID == 1 ? 100000 : 1000000);
+  $targetTries = ($playerID == 1 ? 10 : 100);
+  $waitTime = 1000000;
   while (!file_exists($filename) && $fileTries < $targetTries) {
-    usleep($waitTime); //100ms
+    usleep($waitTime); //1 second
     ++$fileTries;
   }
   if ($fileTries == $targetTries) {
-    if ($playerID == 1) {
-      $errorFileName = "./BugReports/CreateGameFailsafe.txt";
-      $errorHandler = fopen($errorFileName, "a");
-      date_default_timezone_set('America/Chicago');
-      $errorDate = date('m/d/Y h:i:s a');
-      $errorOutput = "Create game failsafe hit for game $gameName at $errorDate";
-      fwrite($errorHandler, $errorOutput . "\r\n");
-      fclose($errorHandler);
-      include "HostFiles/Redirector.php";
-      header("Location: " . $redirectPath . "/Start.php?gameName=$gameName&playerID=1");
-    } else {
-      echo ("This game no longer exists on the server. Please go to the main menu and create a new game.");
-      $errorFileName = "./BugReports/CreateGameFailsafe.txt";
-      $errorHandler = fopen($errorFileName, "a");
-      date_default_timezone_set('America/Chicago');
-      $errorDate = date('m/d/Y h:i:s a');
-      $errorOutput = "Final create game error for game $gameName at $errorDate (total failure)";
-      fwrite($errorHandler, $errorOutput . "\r\n");
-      fclose($errorHandler);
-    }
+    $response = new stdClass();
+    $response->error = "Unable to create the game after 10 seconds. Please try again.";
+    echo(json_encode($response));
     exit;
   }
 

--- a/Start.php
+++ b/Start.php
@@ -98,15 +98,9 @@ $isReplay = 0;
 WriteCache($gameName, ($currentUpdate + 1) . "!" . $currentTime . "!" . $currentTime . "!-1!-1!" . $currentTime . "!"  . $p1Hero . "!" . $p2Hero . "!" . $currentPlayer . "!" . $isReplay . "!0!0"); //Initialize SHMOP cache for this game
 
 ob_start();
+include "ParseGamestate.php";
 include "StartEffects.php";
 ob_end_clean();
-
-$gameStateTries = 0;
-while (!file_exists($filename) && $gameStateTries < 10) {
-  usleep(100000); //100ms
-  ++$gameStateTries;
-}
-
 //Update the game file to show that the game has started and other players can join to spectate
 $gameStatus = $MGS_GameStarted;
 WriteGameFile();

--- a/Start.php
+++ b/Start.php
@@ -13,6 +13,7 @@ include "Libraries/UILibraries2.php";
 include "AI/CombatDummy.php";
 include_once "./includes/dbh.inc.php";
 include_once "./includes/functions.inc.php";
+include_once "./MenuFiles/StartHelper.php";
 ob_end_clean();
 
 $gameName = $_GET["gameName"];
@@ -115,110 +116,5 @@ header("Location: " . $redirectPath . "/NextTurn4.php?gameName=$gameName&playerI
 
 exit;
 
-function initializePlayerState($handler, $deckHandler, $player)
-{
-  global $p1IsPatron, $p2IsPatron, $p1IsChallengeActive, $p2IsChallengeActive, $p1id, $p2id;
-  global $SET_AlwaysHoldPriority, $SET_TryUI2, $SET_DarkMode, $SET_ManualMode, $SET_SkipARs, $SET_SkipDRs, $SET_PassDRStep, $SET_AutotargetArcane;
-  global $SET_ColorblindMode, $SET_EnableDynamicScaling, $SET_Mute, $SET_Cardback, $SET_IsPatron;
-  global $SET_MuteChat, $SET_DisableStats, $SET_CasterMode, $SET_Language;
-  $charEquip = GetArray($deckHandler);
-  $deckCards = GetArray($deckHandler);
-  $deckSize = count($deckCards);
-  fwrite($handler, "\r\n"); //Hand
-
-  if($player == 1) $p1IsChallengeActive = "0";
-  else if($player == 2) $p2IsChallengeActive = "0";
-
-  //Equipment challenge
-  /*
-  if($charEquip[0] != "ARC001" && $charEquip[0] != "ARC002" && $charEquip[1] == "CRU177")
-  {
-    if($player == 1) $p1IsChallengeActive = "1";
-    else if($player == 2) $p2IsChallengeActive = "1";
-  }
-  */
-/*
-  $challengeThreshold = (CharacterHealth($charEquip[0]) > 25 ? 6 : 4);
-  $numChallengeCard = 0;
-  for($i=0; $i<count($deckCards); ++$i)
-  {
-    if($deckCards[$i] == "ARC185") ++$numChallengeCard;
-    if($deckCards[$i] == "ARC186") ++$numChallengeCard;
-    if($deckCards[$i] == "ARC187") ++$numChallengeCard;
-  }
-  if($player == 1 && $numChallengeCard >= $challengeThreshold) $p1IsChallengeActive = "1";
-  else if($player == 2 && $numChallengeCard >= $challengeThreshold) $p2IsChallengeActive = "1";
-*/
-  fwrite($handler, implode(" ", $deckCards) . "\r\n");
-
-  for ($i = 0; $i < count($charEquip); ++$i) {
-    fwrite($handler, $charEquip[$i] . " 2 0 0 0 " . CharacterNumUsesPerTurn($charEquip[$i]) . " 0 0 0 " . CharacterDefaultActiveState($charEquip[$i]) . ($i < count($charEquip) - 1 ? " " : "\r\n"));
-  }
-  //Character and equipment. First is ID. Four numbers each. First is status (0=Destroy/unavailable, 1=Used, 2=Unused, 3=Disabled). Second is num counters
-  //Third is attack modifier, fourth is block modifier
-  //Order: Character, weapon 1, weapon 2, head, chest, arms, legs
-  fwrite($handler, "0 0\r\n"); //Resources float/needed
-  fwrite($handler, "\r\n"); //Arsenal
-  fwrite($handler, "\r\n"); //Item
-  fwrite($handler, "\r\n"); //Aura
-  fwrite($handler, "\r\n"); //Discard
-  fwrite($handler, "\r\n"); //Pitch
-  fwrite($handler, "\r\n"); //Banish
-  fwrite($handler, "0 0 0 0 0 0 0 0 DOWN 0 -1 0 0 0 0 0 0 -1 0 0 0 0 NA 0 0 0 - -1 0 0 0 0 0 0 - 0 0 0 0 0 0 - 0 - - 0 -1 0 0 0 0 0 - 0 0 0 0 0 -1 0 - 0 0 - 0 0\r\n"); //Class State
-  fwrite($handler, "\r\n"); //Character effects
-  fwrite($handler, "\r\n"); //Soul
-  fwrite($handler, "\r\n"); //Card Stats
-  fwrite($handler, "\r\n"); //Turn Stats
-  fwrite($handler, "\r\n"); //Allies
-  fwrite($handler, "\r\n"); //Permanents
-  //$holdPriority = ($charEquip[0] == "ARC113" || $charEquip[0] == "ARC114" ? "1" : "0");
-  $holdPriority = "0"; //Auto-pass layers
-  $isPatron = ($player == 1 ? $p1IsPatron : $p2IsPatron);
-  if($isPatron == "") $isPatron = "0";
-  $mute = 0;
-  $userId = ($player == 1 ? $p1id : $p2id);
-  $savedSettings = LoadSavedSettings($userId);
-  $settingArray = [];
-  for($i=0; $i<=22; ++$i)
-  {
-    $value = "";
-    switch($i)
-    {
-      case $SET_Mute: $value = $mute; break;
-      case $SET_IsPatron: $value = $isPatron; break;
-      default: $value = SettingDefaultValue($i); break;
-    }
-    array_push($settingArray, $value);
-  }
-  for($i=0; $i<count($savedSettings); $i+=2)
-  {
-    //echo($savedSettings[intval($i)] . " " . $savedSettings[intval($i)+1] . "<BR>");
-    $settingArray[$savedSettings[intval($i)]] = $savedSettings[intval($i)+1];
-  }
-  fwrite($handler, implode(" ", $settingArray) . "\r\n"); //Settings
-  //fwrite($handler, $holdPriority . " 1 0 0 0 0 0 1 0 0 0 " . $mute . " 0 " . $isPatron . " 0 0 0 0\r\n"); //Settings
-}
-
-
-
-function SettingDefaultValue($setting)
-{
-  global $SET_AlwaysHoldPriority, $SET_TryUI2, $SET_DarkMode, $SET_ManualMode, $SET_SkipARs, $SET_SkipDRs, $SET_PassDRStep, $SET_AutotargetArcane;
-  global $SET_ColorblindMode, $SET_EnableDynamicScaling, $SET_Mute, $SET_Cardback, $SET_IsPatron;
-  global $SET_MuteChat, $SET_DisableStats, $SET_CasterMode, $SET_Language;
-  switch($setting)
-  {
-    case $SET_TryUI2: return "1";
-    case $SET_AutotargetArcane: return "1";
-    default: return "0";
-  }
-}
-
-function GetArray($handler)
-{
-  $line = trim(fgets($handler));
-  if ($line == "") return [];
-  return explode(" ", $line);
-}
 
 ?>

--- a/StartEffects.php
+++ b/StartEffects.php
@@ -1,7 +1,7 @@
 <?php
 
-include "ParseGamestate.php";
-include "WriteLog.php";
+//include "ParseGamestate.php";
+//include "WriteLog.php";
 
 array_push($layerPriority, ShouldHoldPriority(1));
 array_push($layerPriority, ShouldHoldPriority(2));
@@ -22,7 +22,7 @@ StatsStartTurn();
 $MakeStartTurnBackup = false;
 $MakeStartGameBackup = false;
 
-WriteLog("If you see a bug, use the Report Bug button in the menu. There is also a manual control mode to help correct the game state.");
+//WriteLog("If you see a bug, use the Report Bug button in the menu. There is also a manual control mode to help correct the game state.");
 
 if ($p2Char[0] == "DUMMY") {
   SetCachePiece($gameName, 3, "99999999999999");
@@ -76,12 +76,12 @@ if(SearchCharacterForCard(2, "DYN234")) {
 if (SearchCharacterForCard(1, "DYN026")) {
   $index = FindCharacterIndex(1, "DYN026");
   $p1Char[$index + 4] = -2;
-  WriteLog("When you equip " . CardLink("DYN026", "DYN026") . " it gets two -1 counters.");
+  //WriteLog("When you equip " . CardLink("DYN026", "DYN026") . " it gets two -1 counters.");
 }
 if (SearchCharacterForCard(2, "DYN026")) {
   $index = FindCharacterIndex(2, "DYN026");
   $p2Char[$index + 4] = -2;
-  WriteLog("When you equip " . CardLink("DYN026", "DYN026") . " it gets two -1 counters.");
+  //WriteLog("When you equip " . CardLink("DYN026", "DYN026") . " it gets two -1 counters.");
 }
 
 AddDecisionQueue("SHUFFLEDECK", 1, "SKIPSEED"); //CR 2.0 4.1.7 Shuffle Deck

--- a/SubmitSideboard.php
+++ b/SubmitSideboard.php
@@ -83,8 +83,6 @@ if ($playerCharacter != "" && $playerDeck != "") //If they submitted before load
 
 if ($playerID == 2) {
   $gameStatus = $MGS_ReadyToStart;
-} else {
-  $gameStatus = $MGS_GameStarted;
 }
 WriteGameFile();
 GamestateUpdated($gameName);

--- a/WriteGamestate.php
+++ b/WriteGamestate.php
@@ -2,7 +2,7 @@
 
 UpdateGameState($playerID);
 
-$filename = "./Games/" . $gameName . "/gamestate.txt";
+if(!isset($filename) || !str_contains($filename, "gamestate.txt")) $filename = "./Games/" . $gameName . "/gamestate.txt";
 $handler = fopen($filename, "w");
 
 $lockTries = 0;


### PR DESCRIPTION
Redirects are bad for the react FE. It pulls you out of the FE, so we need to get rid of them. This redirect is in ParseGamestate.php. It calls Start.php if it doesn't find the gamestate file after 500ms. It's not super clear why this code exists. I think it's to get rid of conflicts between IO bottlenecks, write times, memory write times, etc. sometimes all happening at different speeds. Checking 5 times at 100ms intervals seems excessively few number of tries, and excessively close together. Changing this to 10 tries at 1 second intervals expands the game creation attempt window out to 10 seconds, which seems like it should be way more than enough time. I don't think re-calling Start should ever be necessary.