### PR TITLE
Close combat chain triggers fire before end step

### DIFF
--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -1022,10 +1022,15 @@ function CleanUpCombatEffects($weaponSwap = false)
 
 function BeginTurnPass()
 {
-  global $mainPlayer, $defPlayer, $decisionQueue;
-  WriteLog("Main player passed priority; attempting to end turn");
+  global $mainPlayer, $defPlayer, $decisionQueue, $layers;
   ResetCombatChainState(); // The combat chain must be closed prior to the turn ending. The close step is outlined in 7.8 - specifically: CR 2.1 - 7.8.7. Fifth and finally, the Close Step ends, and the Action Phase continues. The Action Phase will always continue after the combat chain is closed - so there is another round of priority windows
-  AddLayer("ENDTURN", $mainPlayer, "-");
+
+  // Only attempt to end turn if no triggers remain on stack
+  if ($layers[0] != 'TRIGGER') {
+    WriteLog("Main player passed priority; attempting to end turn");
+    AddLayer("ENDTURN", $mainPlayer, "-");
+  }
+
   ProcessDecisionQueue("");
 }
 


### PR DESCRIPTION
If a player passes, triggering the combat chain to close, triggers can be added to the stack by cards that add triggers when the combat chain is closed, e.g.  Hell Hammer and mark of the beast.

This adds a check to make sure no triggers remain on the stack before adding the end turn layer.