### PR TITLE
Bugfix Spellvoid triggers to only trigger with hold priority

### DIFF
--- a/Search.php
+++ b/Search.php
@@ -748,6 +748,7 @@ function SearchArcaneReplacement($player, $zone)
   for ($i = 0; $i < count($array); $i += $count) {
     if ($zone == "MYCHAR" && !IsCharacterAbilityActive($player, $i)) continue;
     $cardID = $array[$i];
+    if ($array[$i+7] == 0) continue;
     if (SpellVoidAmount($cardID, $player) > 0 && IsCharacterActive($player, $i)) {
       if ($cardList != "") $cardList = $cardList . ",";
       $cardList = $cardList . $i;


### PR DESCRIPTION
# Fixed a bug when spellvoid auras would trigger even if the gem is turned off (don't hold priority)

Issue: [570](https://github.com/Talishar/Talishar/issues/570)