### PR TITLE
Bugfix: Removed empty objects and null arrays from GetNextTurn3 response

### DIFF
--- a/Libraries/UILibraries2.php
+++ b/Libraries/UILibraries2.php
@@ -124,11 +124,11 @@ function JSONRenderedCard(
     'isBroken' => $isBroken,
     'onChain' => $onChain,
     'isFrozen' => $isFrozen,
-    'countersMap' => $countersMap,
+    'countersMap' => $countersMap == json_decode('{}') ? null : $countersMap,
     'label' => $label,
     'facing' => $facing,
     'numUses' => $numUses,
-    'subcards' => [$subcard]
+    'subcards' => $subcard == NULL ? null : [$subcard]
   ];
 
   if ($gem != NULL) {


### PR DESCRIPTION
Looked into the issue [574](https://github.com/Talishar/Talishar/issues/574)

- Found that `countersMap` always created as an empty object no matter what it's context is. 
- Found that `subcards` is always converted into an array even if it's `NULL` (that's the default value).

I'm not entirely sure if my fix could break stuff on the front end side but I'm almost certain it won't. As I saw the [Card interface](https://github.com/Talishar/Talishar-FE/blob/main/src/features/Card.ts) uses `countersMap` and `subcards` as conditional properties.

I have tested few games with Dromai and Dorinthea and nothing broke.