### PR TITLE
Outsiders bug fixes

### DIFF
--- a/CardLogic.php
+++ b/CardLogic.php
@@ -46,11 +46,11 @@ function BottomDeck($player="", $mayAbility=false, $shouldDraw=false)
   if($shouldDraw) AddDecisionQueue("DRAW", $player, "-", 1);
 }
 
-function BottomDeckMultizone($player, $zone1, $zone2)
+function BottomDeckMultizone($player, $zone1, $zone2, $isMandatory = false, $context = "Choose a card to sink (or Pass)")
 {
   AddDecisionQueue("MULTIZONEINDICES", $player, $zone1 . "&" . $zone2, 1);
-  AddDecisionQueue("SETDQCONTEXT", $player, "Choose a card to sink (or Pass)", 1);
-  AddDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
+  AddDecisionQueue("SETDQCONTEXT", $player, $context, 1);
+  AddDecisionQueue($isMandatory ? "CHOOSEMULTIZONE" : "MAYCHOOSEMULTIZONE", $player, "<-", 1);
   AddDecisionQueue("MZREMOVE", $player, "-", 1);
   AddDecisionQueue("ADDBOTDECK", $player, "-", 1);
 }
@@ -1015,17 +1015,11 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target="-")
       DestroyAuraUniqueID($player, $uniqueID);
       break;
     case $CID_Inertia:
-      $deck = new Deck($player);
-      $arsenal = &GetArsenal($player);
-      while(count($arsenal) > 0) {
-        $deck->AddBottom($arsenal[0], "ARS");
-        RemoveArsenal($player, 0);
+      WriteLog("Processing the end of turn effect of Inertia.");
+      for ($i = 0; $i < count(GetArsenal($player)) + count(GetHand($player)); $i++) {
+        BottomDeckMultizone($player, "MYHAND", "MYARS", true, " ");
       }
-      $hand = &GetHand($player);
-      while(count($hand) > 0) {
-        $deck->AddBottom($hand[0], "HAND");
-        RemoveHand($player, 0);
-      }
+      AddDecisionQueue("WRITELOG", $player, ("Player " . $player . " cards and arsenal was put on the bottom of their deck."));
       DestroyAuraUniqueID($player, $uniqueID);
       break;
     case $CID_Frailty:

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -1020,7 +1020,7 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target="-")
       for ($i = 0; $i < count(GetArsenal($player)) + count(GetHand($player)); $i++) {
         BottomDeckMultizone($player, "MYHAND", "MYARS", true, "Choose a card from your hand or arsenal to add to the bottom of your deck");
       }
-      AddDecisionQueue("WRITELOG", $player, ("Player " . $player . " cards and arsenal was put on the bottom of their deck."));
+      AddDecisionQueue("WRITELOG", $player, ("The cards and arsenal of Player " . $player . " was put on the bottom of their deck."));
       DestroyAuraUniqueID($player, $uniqueID);
       break;
     case $CID_Frailty:

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -46,11 +46,11 @@ function BottomDeck($player="", $mayAbility=false, $shouldDraw=false)
   if($shouldDraw) AddDecisionQueue("DRAW", $player, "-", 1);
 }
 
-function BottomDeckMultizone($player, $zone1, $zone2)
+function BottomDeckMultizone($player, $zone1, $zone2, $isMandatory = false, $context = "Choose a card to sink (or Pass)")
 {
   AddDecisionQueue("MULTIZONEINDICES", $player, $zone1 . "&" . $zone2, 1);
-  AddDecisionQueue("SETDQCONTEXT", $player, "Choose a card to sink (or Pass)", 1);
-  AddDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
+  AddDecisionQueue("SETDQCONTEXT", $player, $context, 1);
+  AddDecisionQueue($isMandatory ? "CHOOSEMULTIZONE" : "MAYCHOOSEMULTIZONE", $player, "<-", 1);
   AddDecisionQueue("MZREMOVE", $player, "-", 1);
   AddDecisionQueue("ADDBOTDECK", $player, "-", 1);
 }
@@ -1016,16 +1016,11 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target="-")
       break;
     case $CID_Inertia:
       $deck = new Deck($player);
-      $arsenal = &GetArsenal($player);
-      while(count($arsenal) > 0) {
-        $deck->AddBottom($arsenal[0], "ARS");
-        RemoveArsenal($player, 0);
+      WriteLog("Processing the end of turn effect of Inertia.");
+      for ($i = 0; $i < count(GetArsenal($player)) + count(GetHand($player)); $i++) {
+        BottomDeckMultizone($player, "MYHAND", "MYARS", true, "Choose a card from your hand or arsenal to add to the bottom of your deck");
       }
-      $hand = &GetHand($player);
-      while(count($hand) > 0) {
-        $deck->AddBottom($hand[0], "HAND");
-        RemoveHand($player, 0);
-      }
+      AddDecisionQueue("WRITELOG", $player, ("Player " . $player . " cards and arsenal was put on the bottom of their deck."));
       DestroyAuraUniqueID($player, $uniqueID);
       break;
     case $CID_Frailty:

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -46,11 +46,11 @@ function BottomDeck($player="", $mayAbility=false, $shouldDraw=false)
   if($shouldDraw) AddDecisionQueue("DRAW", $player, "-", 1);
 }
 
-function BottomDeckMultizone($player, $zone1, $zone2, $isMandatory = false, $context = "Choose a card to sink (or Pass)")
+function BottomDeckMultizone($player, $zone1, $zone2)
 {
   AddDecisionQueue("MULTIZONEINDICES", $player, $zone1 . "&" . $zone2, 1);
-  AddDecisionQueue("SETDQCONTEXT", $player, $context, 1);
-  AddDecisionQueue($isMandatory ? "CHOOSEMULTIZONE" : "MAYCHOOSEMULTIZONE", $player, "<-", 1);
+  AddDecisionQueue("SETDQCONTEXT", $player, "Choose a card to sink (or Pass)", 1);
+  AddDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
   AddDecisionQueue("MZREMOVE", $player, "-", 1);
   AddDecisionQueue("ADDBOTDECK", $player, "-", 1);
 }
@@ -1015,11 +1015,17 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target="-")
       DestroyAuraUniqueID($player, $uniqueID);
       break;
     case $CID_Inertia:
-      WriteLog("Processing the end of turn effect of Inertia.");
-      for ($i = 0; $i < count(GetArsenal($player)) + count(GetHand($player)); $i++) {
-        BottomDeckMultizone($player, "MYHAND", "MYARS", true, " ");
+      $deck = new Deck($player);
+      $arsenal = &GetArsenal($player);
+      while(count($arsenal) > 0) {
+        $deck->AddBottom($arsenal[0], "ARS");
+        RemoveArsenal($player, 0);
       }
-      AddDecisionQueue("WRITELOG", $player, ("Player " . $player . " cards and arsenal was put on the bottom of their deck."));
+      $hand = &GetHand($player);
+      while(count($hand) > 0) {
+        $deck->AddBottom($hand[0], "HAND");
+        RemoveHand($player, 0);
+      }
       DestroyAuraUniqueID($player, $uniqueID);
       break;
     case $CID_Frailty:

--- a/CardSetters.php
+++ b/CardSetters.php
@@ -64,6 +64,10 @@ function BanishCard(&$banish, &$classState, $cardID, $modifier, $player = "", $f
       AddLayer("TRIGGER", $player, $character[$index]);
     }
   }
+  if ($from == "EQUIP") {
+    $charIndex = FindCharacterIndex($player, $cardID);
+    DestroyCharacter($player, $charIndex, true);
+  }
   if($banishedBy != "") CheckContracts($banishedBy, $cardID);
   return $rv;
 }

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -166,6 +166,9 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
       if(count($params) < 3) array_push($params, "");
       $mzIndices = "";
       for($i = 0; $i < count($cards); ++$i) {
+        if (CardType($cards[$i]) == "E") {
+          $params[0] = "EQUIP";
+        }
         $index = BanishCardForPlayer($cards[$i], $player, $params[0], $params[1], $params[2]);
         if($mzIndices != "") $mzIndices .= ",";
         $mzIndices .= "BANISH-" . $index;


### PR DESCRIPTION
### 1. Fixed the issue [488](https://github.com/Talishar/Talishar/issues/488). The player is now able to, and required to select, in which order do they desire their cards to be put on the bottom of their deck.

- Now logging 2 messages, the first is sent as a reminder to the opponent, that the active player is choosing the order of the cards. The second is sent when all the cards (from hand and arsenal) were put into the bottom of their deck.

![Screenshot from 2023-09-20 17-45-07](https://github.com/Talishar/Talishar/assets/39841262/5ccd6e2b-2be5-46ab-b8f8-92f908067d95)

- A popup is created similar to Crown of Providence's, but this is a mandatory trigger hence there is no such option to 'pass'.

![Screenshot from 2023-09-20 17-32-55](https://github.com/Talishar/Talishar/assets/39841262/e8f7c821-36c6-4f32-b5cd-34a270586c98)

### 2. Fixed the issue [465](https://github.com/Talishar/Talishar/issues/465). Now random defending equipments banished from previous chains also. 
An example case:
![Screenshot from 2023-09-20 21-39-03](https://github.com/Talishar/Talishar/assets/39841262/5d8de8a4-bd44-4d6e-83eb-c8b1ce986104)
........................................
![Screenshot from 2023-09-20 21-39-54](https://github.com/Talishar/Talishar/assets/39841262/6a2482a7-da4e-42a1-91d1-612c44ced557)

### 3. Fixed a `MULTIBANISH` to destroy equipments on banish.
![image](https://github.com/Talishar/Talishar/assets/39841262/6c2d5a1b-9027-40a9-a13c-f922c6693687)
