### PR TITLE
Spellvoid hotfix

### DIFF
--- a/CardSetters.php
+++ b/CardSetters.php
@@ -64,7 +64,7 @@ function BanishCard(&$banish, &$classState, $cardID, $modifier, $player = "", $f
       AddLayer("TRIGGER", $player, $character[$index]);
     }
   }
-  if ($from == "EQUIP") {
+  if (CardType($cardID) == "E") {
     $charIndex = FindCharacterIndex($player, $cardID);
     DestroyCharacter($player, $charIndex, true);
   }

--- a/CombatChain.php
+++ b/CombatChain.php
@@ -387,12 +387,11 @@ function OnBlockResolveEffects()
 }
 
 function GetDefendingEquipmentsFromCombatChainLink($chainLink, $defPlayer) {
+  // returns array of equipments played by the defending hero which is still on the chain
   $defendingEquipments = array();
   for ($i = 0; $i < count($chainLink); $i += ChainLinksPieces()) {
-    // if it's an equipment played by the defending hero which is still on the chain
     if ($chainLink[$i+3] == "EQUIP" && $chainLink[$i+2] == 1 && $chainLink[$i+1] == $defPlayer) {
       array_push($defendingEquipments, $chainLink[$i]);
-      //WriteLog($chainLink[$i] . " is an equipment");
     }
   }
   return $defendingEquipments;
@@ -408,7 +407,6 @@ function BeginningReactionStepEffects()
       {
         $equipmentsToBanish = array();
 
-        // populate equipmentsToBanish from previous chain links's history
         for($i=0; $i<count($chainLinks); $i++) {
           if (count($chainLinks[$i]) == ChainLinksPieces()) continue;
           $defendingEquipments = GetDefendingEquipmentsFromCombatChainLink($chainLinks[$i], $defPlayer);
@@ -418,7 +416,6 @@ function BeginningReactionStepEffects()
           }
         }
         
-        // add the currently defending equipments
         $defendingEquipments = GetChainLinkCards($defPlayer, "E");
         if ($defendingEquipments != "") {
           $defendingEquipments = explode(",", $defendingEquipments);

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -166,9 +166,6 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
       if(count($params) < 3) array_push($params, "");
       $mzIndices = "";
       for($i = 0; $i < count($cards); ++$i) {
-        if (CardType($cards[$i]) == "E") {
-          $params[0] = "EQUIP";
-        }
         $index = BanishCardForPlayer($cards[$i], $player, $params[0], $params[1], $params[2]);
         if($mzIndices != "") $mzIndices .= ",";
         $mzIndices .= "BANISH-" . $index;

--- a/Search.php
+++ b/Search.php
@@ -748,7 +748,7 @@ function SearchArcaneReplacement($player, $zone)
   for ($i = 0; $i < count($array); $i += $count) {
     if ($zone == "MYCHAR" && !IsCharacterAbilityActive($player, $i)) continue;
     $cardID = $array[$i];
-    if ($array[$i+7] == 0) continue;
+    if ((CardType($cardID) == "A" || CardType($cardID) == "T") && $array[$i+7] == 0) continue;
     if (SpellVoidAmount($cardID, $player) > 0 && IsCharacterActive($player, $i)) {
       if ($cardList != "") $cardList = $cardList . ",";
       $cardList = $cardList . $i;


### PR DESCRIPTION
This is a hotfix on spellvoid as my previous fix on Spellbane Aegis now skips equipments automatically (their gem state / priority is handled differently). 
Adjusted the code in yesterdays multibanish fix. This is a bit more proper way to handle that. Also removed my accidentally left in comments.