### PR TITLE
Intimidate update

### DIFF
--- a/CardLogic.php
+++ b/CardLogic.php
@@ -1213,16 +1213,18 @@ function CardDiscarded($player, $discarded, $source = "")
 
 function Intimidate($player="")
 {
-  global $defPlayer;
-  if($player == "") $player = $defPlayer;
-  $hand = &GetHand($player);
-  if(count($hand) == 0) {
-    WriteLog("Intimidate did nothing because there are no cards in hand");
+  global $currentPlayer, $defPlayer;
+  
+  if (!ShouldAutotargetOpponent($currentPlayer) && $player == "") {
+    AddDecisionQueue("MULTIZONEINDICES", $player, "MYCHAR:type=C&THEIRCHAR:type=C", 1);
+    AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose hero to intimidate.", 1);
+    AddDecisionQueue("CHOOSEMULTIZONE", $currentPlayer, "<-", 1);
+    AddDecisionQueue("INTIMIDATE", $currentPlayer, "-" , 1);
     return;
   }
-  $index = GetRandom() % count($hand);
-  BanishCardForPlayer($hand[$index], $player, "HAND", "INT");
-  RemoveHand($player, $index);
+
+  if ($player != "") AddDecisionQueue("INTIMIDATE", $currentPlayer, $player , 1);
+  else AddDecisionQueue("INTIMIDATE", $currentPlayer, $defPlayer , 1);
 }
 
 function DestroyFrozenArsenal($player)

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -1305,6 +1305,20 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
       $params = explode(",", $parameter);
       if(CardType($params[0]) == "AA" || GetResolvedAbilityType($params[0], $params[1]) == "AA") GetTargetOfAttack();
       return $lastResult;
+    case "INTIMIDATE":
+      if ($parameter != "-") $player = $parameter;
+      else $player = $lastResult == "MYCHAR-0" ? $currentPlayer : $defPlayer;
+      WriteLog("Player {$player} was targeted to intimidate.");
+      $hand = &GetHand($player);
+      if(count($hand) == 0) {
+        WriteLog("Intimidate did nothing because there are no cards in their hand");
+        return;
+      }
+      $index = GetRandom() % count($hand);
+      BanishCardForPlayer($hand[$index], $player, "HAND", "INT");
+      RemoveHand($player, $index);
+      WriteLog("Player {$player} banishes a card face down");
+      return $player;
     default:
       return "NOTSTATIC";
   }

--- a/Libraries/CoreLibraries.php
+++ b/Libraries/CoreLibraries.php
@@ -26,9 +26,15 @@ function SeedRandom()
   if(count($combatChain) > 0) for($i=0; $i<count($combatChain); ++$i) $seedString .= $combatChain[$i];
 
   $char = &GetPlayerCharacter(1);
-  for($i=0; $i<count($char); ++$i) $seedString .= $char[$i];
+  for($i=0; $i<count($char); ++$i) {
+    if ($i % CharacterPieces() == 9) continue;
+    $seedString .= $char[$i];
+  }
   $char = &GetPlayerCharacter(2);
-  for($i=0; $i<count($char); ++$i) $seedString .= $char[$i];
+  for($i=0; $i<count($char); ++$i) {
+    if ($i % CharacterPieces() == 9) continue;
+    $seedString .= $char[$i];
+  }
 
   $banish = &GetBanish(1);
   for($i=0; $i<count($banish); ++$i) $seedString .= $banish[$i];

--- a/Search.php
+++ b/Search.php
@@ -121,7 +121,7 @@ function SearchInner(&$array, $player, $zone, $count, $type, $subtype, $maxCost,
         && ($minAttack == -1 || AttackValue($cardID) >= $minAttack)
         && ($maxDef == -1 || BlockValue($cardID) <= $maxDef)
       ) {
-        if($bloodDebtOnly && !HasBloodDebt($cardID)) continue;
+        if($bloodDebtOnly && (!HasBloodDebt($cardID) || $array[$i+1] == "INT")) continue;
         if($phantasmOnly && !HasPhantasm($cardID)) continue;
         if($specOnly && !IsSpecialization($cardID)) continue;
         if($frozenOnly && !IsFrozenMZ($array, $zone, $i)) continue;


### PR DESCRIPTION
Please review and playtest before merge as this affects a core game mechanic.
Scowling Flesh Bag should work also

- Fixed issue #313 Now you are able to intimidate yourself when using manual targeting option. Without that, the enemy hero is affected
- Fixed an issue that the gems on the equipments are affecting the rng. For example previously if you discarded from your hand and then pressed undo to toggle the gems around on your equipments, that caused that when you replayed the exact same line, you could be almost sure about something else getting discarded.
- Fixed an issue when intimidated cards counted towards to the blood dept on the newer front end. This could be game changing in very rare scenarios as in the late game knowing that intimidate hit a non blood dept card can give out valuable information (opponent now drew  up the pitch stacked AoW / BrB)