### PR TITLE
Burdens of the past

### DIFF
--- a/CardDictionaries/Outsiders/OUTShared.php
+++ b/CardDictionaries/Outsiders/OUTShared.php
@@ -537,7 +537,7 @@ function OUTAbilityCost($cardID)
           AddDecisionQueue("BUTTONINPUT", $currentPlayer, "Target_Opponent,Target_Yourself");
           AddDecisionQueue("PLAYERTARGETEDABILITY", $currentPlayer, "BURDENSOFTHEPAST", 1);
         }
-        return "This is a partially manual card - Enforce defense reaction play restriction manually";
+        return "";
       case "OUT188":
         AddCurrentTurnEffect($cardID . "_1", $currentPlayer);
         AddCurrentTurnEffect($cardID . "_2", $currentPlayer);

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -457,7 +457,7 @@ function IsPlayable($cardID, $phase, $from, $index = -1, &$restriction = null, $
   $cardType = CardType($cardID);
   $subtype = CardSubType($cardID);
   $abilityType = GetAbilityType($cardID, $index, $from);
-  if(($phase == "DF" || $phase == "AF" || $phase == "M" || $phase == "INSTANT") && EffectPlayCardRestricted($cardID, CardType($cardID), false, $restriction)) return false;
+  if(($phase == "DR" || $phase == "AR" || $phase == "M" || $phase == "INSTANT") && EffectPlayCardRestricted($cardID, CardType($cardID), false, $restriction)) return false;
   if($phase == "P" && $from != "HAND") return false;
   if($phase == "B" && $from == "BANISH") return false;
   if($from == "BANISH") {

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -457,6 +457,7 @@ function IsPlayable($cardID, $phase, $from, $index = -1, &$restriction = null, $
   $cardType = CardType($cardID);
   $subtype = CardSubType($cardID);
   $abilityType = GetAbilityType($cardID, $index, $from);
+  if(($phase == "DF" || $phase == "AF" || $phase == "M" || $phase == "INSTANT") && EffectPlayCardRestricted($cardID, CardType($cardID), false, $restriction)) return false;
   if($phase == "P" && $from != "HAND") return false;
   if($phase == "B" && $from == "BANISH") return false;
   if($from == "BANISH") {

--- a/CurrentEffectAbilities.php
+++ b/CurrentEffectAbilities.php
@@ -1121,27 +1121,29 @@ function EffectAttackRestricted()
   return false;
 }
 
-function EffectPlayCardRestricted($cardID, $type)
+function EffectPlayCardRestricted($cardID, $type, $revertGamestate = true, &$restriction = "")
 {
   global $currentTurnEffects, $currentPlayer;
-  $restrictedBy = "";
   for($i = count($currentTurnEffects) - CurrentTurnPieces(); $i >= 0; $i -= CurrentTurnPieces()) {
     if($currentTurnEffects[$i+1] == $currentPlayer) {
       $effectArr = explode(",", $currentTurnEffects[$i]);
       $effectID = $effectArr[0];
       switch($effectID) {
-        case "ARC162": if(GamestateSanitize(CardName($cardID)) == $effectArr[1]) $restrictedBy = "ARC162"; break;
-        case "DTD226": if(CardType($cardID) != "W" && GamestateSanitize(CardName($cardID)) == $effectArr[1]) $restrictedBy = "DTD226"; break;
-        case "DTD230-War": if($type == "A" && CardType($cardID) != "W") $restrictedBy = "DTD230"; break;
-        case "DTD230-Peace": if($type == "AA" || (CardType($cardID) == "W" && GetResolvedAbilityType($cardID) != "I")) $restrictedBy = "DTD230"; break;
+        case "ARC162": if(GamestateSanitize(CardName($cardID)) == $effectArr[1]) $restriction = "ARC162"; break;
+        case "DTD226": if(CardType($cardID) != "W" && GamestateSanitize(CardName($cardID)) == $effectArr[1]) $restriction = "DTD226"; break;
+        case "OUT187": if(in_array(GamestateSanitize(CardName($cardID)), $effectArr)) $restriction = "OUT187"; break;
+        case "DTD230-War": if($type == "A" && CardType($cardID) != "W") $restriction = "DTD230"; break;
+        case "DTD230-Peace": if($type == "AA" || (CardType($cardID) == "W" && GetResolvedAbilityType($cardID) != "I")) $restriction = "DTD230"; break;
         default:
           break;
       }
     }
   }
-  if($restrictedBy != "") {
-    WriteLog("The card play is restricted by " . CardLink($restrictedBy, $restrictedBy) . ". Reverting the gamestate.");
-    RevertGamestate();
+  if($restriction != "") {
+    if ($revertGamestate) {
+      WriteLog("The card play is restricted by " . CardLink($restriction, $restriction) . ". Reverting the gamestate.");
+      RevertGamestate();
+    }
     return true;
   }
   return false;

--- a/DecisionQueue/DecisionQueueEffects.php
+++ b/DecisionQueue/DecisionQueueEffects.php
@@ -193,8 +193,14 @@ function PlayerTargetedAbility($player, $card, $lastResult)
       if(PitchValue($banished) == $pitchTarget) LoseHealth(1, $target);
       return "";
     case "BURDENSOFTHEPAST":
-      if(SearchCount(SearchDiscard($target, "DR")) >= 10) Draw($player);
-      AddCurrentTurnEffect("OUT187", $target);
+      $defenseReactionsInDiscard = SearchDiscard($target, "DR", getDistinctCardNames: true);
+      WriteLog("Player {$target} was targeted. Burdens of the Past prevents the play of the folowing defense reactions: <b>" . (str_replace("_", " ", $defenseReactionsInDiscard)) . "</b>");
+      AddCurrentTurnEffect("OUT187," . $defenseReactionsInDiscard, $target);
+      if(SearchCount(SearchDiscard($target, "DR")) >= 10) {
+        WriteLog("Player {$player} draws a card as target hero has at least 10 defense reactions in their graveyard.");
+        Draw($player);
+      }
+
       return "";
     default: return $lastResult;
   }

--- a/Search.php
+++ b/Search.php
@@ -29,10 +29,10 @@ function SearchPitch($player, $type = "", $subtype = "", $maxCost = -1, $minCost
   return SearchInner($searchPitch, $player, "PITCH", PitchPieces(), $type, $subtype, $maxCost, $minCost, $class, $talent, $bloodDebtOnly, $phantasmOnly, $pitch, $specOnly, $maxAttack, $maxDef, $frozenOnly, $hasNegCounters, $hasEnergyCounters, $comboOnly, $minAttack);
 }
 
-function SearchDiscard($player, $type = "", $subtype = "", $maxCost = -1, $minCost = -1, $class = "", $talent = "", $bloodDebtOnly = false, $phantasmOnly = false, $pitch = -1, $specOnly = false, $maxAttack = -1, $maxDef = -1, $frozenOnly = false, $hasNegCounters = false, $hasEnergyCounters = false, $comboOnly = false, $minAttack = false)
+function SearchDiscard($player, $type = "", $subtype = "", $maxCost = -1, $minCost = -1, $class = "", $talent = "", $bloodDebtOnly = false, $phantasmOnly = false, $pitch = -1, $specOnly = false, $maxAttack = -1, $maxDef = -1, $frozenOnly = false, $hasNegCounters = false, $hasEnergyCounters = false, $comboOnly = false, $minAttack = false, $getDistinctCardNames = false)
 {
   $discard = &GetDiscard($player);
-  return SearchInner($discard, $player, "DISCARD", DiscardPieces(), $type, $subtype, $maxCost, $minCost, $class, $talent, $bloodDebtOnly, $phantasmOnly, $pitch, $specOnly, $maxAttack, $maxDef, $frozenOnly, $hasNegCounters, $hasEnergyCounters, $comboOnly, $minAttack);
+  return SearchInner($discard, $player, "DISCARD", DiscardPieces(), $type, $subtype, $maxCost, $minCost, $class, $talent, $bloodDebtOnly, $phantasmOnly, $pitch, $specOnly, $maxAttack, $maxDef, $frozenOnly, $hasNegCounters, $hasEnergyCounters, $comboOnly, $minAttack, $getDistinctCardNames);
 }
 
 function SearchBanish($player, $type = "", $subtype = "", $maxCost = -1, $minCost = -1, $class = "", $talent = "", $bloodDebtOnly = false, $phantasmOnly = false, $pitch = -1, $specOnly = false, $maxAttack = -1, $maxDef = -1, $frozenOnly = false, $hasNegCounters = false, $hasEnergyCounters = false, $comboOnly = false, $minAttack = false)
@@ -102,7 +102,7 @@ function SearchCardList($list, $player, $type = "", $subtype = "", $maxCost = -1
 }
 
 
-function SearchInner(&$array, $player, $zone, $count, $type, $subtype, $maxCost, $minCost, $class, $talents, $bloodDebtOnly, $phantasmOnly, $pitch, $specOnly, $maxAttack, $maxDef, $frozenOnly, $hasNegCounters, $hasEnergyCounters, $comboOnly, $minAttack)
+function SearchInner(&$array, $player, $zone, $count, $type, $subtype, $maxCost, $minCost, $class, $talents, $bloodDebtOnly, $phantasmOnly, $pitch, $specOnly, $maxAttack, $maxDef, $frozenOnly, $hasNegCounters, $hasEnergyCounters, $comboOnly, $minAttack, $getDistinctCardNames = false)
 {
   $cardList = "";
   if (!is_array($talents)) $talents = ($talents == "" ? [] : explode(",", $talents));
@@ -128,8 +128,9 @@ function SearchInner(&$array, $player, $zone, $count, $type, $subtype, $maxCost,
         if($hasNegCounters && $array[$i+4] == 0) continue;
         if($hasEnergyCounters && !HasEnergyCounters($array, $i)) continue;
         if($comboOnly && !HasCombo($cardID)) continue;
+        if ($getDistinctCardNames && str_contains($cardList, GamestateSanitize(CardName($cardID)))) continue; 
         if($cardList != "") $cardList = $cardList . ",";
-        $cardList = $cardList . $i;
+        $cardList = $cardList . ($getDistinctCardNames ? GamestateSanitize(CardName($cardID)) : $i);
       }
     }
   }


### PR DESCRIPTION
### - Added card restriction enforcement to Burdens of the Past.
There was a complaint (_**Chat goes by so fast I didn't see any the opponent didn't see either**_) that Burden's effect can't even be seen so I added logging to the card's effect:
![image](https://github.com/Talishar/Talishar/assets/39841262/5cfdd351-f18a-48e1-9873-720808cd3239)
I found it a big ugly and a bit overkill... but at least it works. Now You shouldn't be able to play defense reactions to an attack which has the same name as a defense reaction in your graveyard, it's enforced.
![image](https://github.com/Talishar/Talishar/assets/39841262/5575eb7b-089c-4717-ba6b-f95a83297615)
### - Added card restriction check to the `IsPlayable` function. The game renders these cards as not playable, they don't have a green border, and you can't click on them / use them.
The restriction is applied in the following phases:
1. M - main phase
2. INSTANT - instant phase
3. AR - attack reaction phase
4. DR - defense reaction phase

You should be able to pitch them, and defend with them. The only exception I found is Chains of Eminence I added a different implementation to that.