### PR TITLE
Mini forcefield

### DIFF
--- a/CardDictionaries/Keywords.php
+++ b/CardDictionaries/Keywords.php
@@ -5,7 +5,8 @@
     if(CardNameContains($cardID, "Hyper Driver", $player) && (SearchCharacterForCard($player, "EVO004") || SearchCharacterForCard($player, "EVO005"))) return true;
     switch($cardID) {
       case "EVO084": case "EVO085": case "EVO086":
-      case "EVO087": case "EVO088": case "EVO089": return true;
+      case "EVO087": case "EVO088": case "EVO089":
+      case "EVO093": case "EVO094": case "EVO095": return true;
       default: return false;
     }
   }

--- a/CardDictionaries/PlayAbilities.php
+++ b/CardDictionaries/PlayAbilities.php
@@ -151,6 +151,13 @@
         --$items[$index+1];
         if($items[$index+1] <= 0) DestroyItemForPlayer($currentPlayer, $index);
         return "";
+      case "EVO093": case "EVO094": case "EVO095":
+        if($from == "PLAY") AddCurrentTurnEffect($cardID, $currentPlayer);
+        $index = GetClassState($currentPlayer, $CS_PlayIndex);
+        $items = &GetItems($currentPlayer);
+        --$items[$index+1];
+        if($items[$index+1] <= 0) DestroyItemForPlayer($currentPlayer, $index);
+        return "";
       case "EVO101":
         $numScrap = 0;
         $costAry = explode(",", $additionalCosts);

--- a/CardDictionaries/PlayAbilities.php
+++ b/CardDictionaries/PlayAbilities.php
@@ -151,13 +151,6 @@
         --$items[$index+1];
         if($items[$index+1] <= 0) DestroyItemForPlayer($currentPlayer, $index);
         return "";
-      case "EVO093": case "EVO094": case "EVO095":
-        if($from == "PLAY") AddCurrentTurnEffect($cardID, $currentPlayer);
-        $index = GetClassState($currentPlayer, $CS_PlayIndex);
-        $items = &GetItems($currentPlayer);
-        --$items[$index+1];
-        if($items[$index+1] <= 0) DestroyItemForPlayer($currentPlayer, $index);
-        return "";
       case "EVO101":
         $numScrap = 0;
         $costAry = explode(",", $additionalCosts);

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -969,8 +969,9 @@ function ETASteamCounters($cardID)
     case "DYN111": return 2;
     case "DYN112": return 1;
     case "EVO084": case "EVO085": case "EVO086": return 1;
-    case "EVO087": return 3;
-    case "EVO088": return 2;
+    case "EVO093": return 4;
+    case "EVO087": case "EVO094": return 3;
+    case "EVO088": case "EVO095": return 2;
     case "EVO089": return 1;
     default: return 0;
   }
@@ -1502,6 +1503,8 @@ function HasWard($cardID, $player)
     case "DTD405": case "DTD406": case "DTD407": case "DTD408"://Angels
     case "DTD409": case "DTD410": case "DTD411": case "DTD412":
       return true;
+    case "EVO093": case "EVO094": case "EVO095":
+        return true;
     default: return false;
   }
 }

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -1484,6 +1484,18 @@ function GetDamagePreventionIndices($player)
   }
   $indices = SearchMultiZoneFormat($indices, "MYCHAR");
   $mzIndices = CombineSearches($mzIndices, $indices);
+
+  $items = &GetItems($player);
+  $itemCount = count($items);
+  for ($i=0; $i<$itemCount; $i+=ItemPieces()) {
+    if (ItemDamagePeventionAmount($player, $i) > 0) {
+      if($indices != "") $indices .= ",";
+      $indices .= $i;
+    }
+  }
+  $indices = SearchMultizoneFormat($indices, "MYITEMS");
+  $mzIndices = CombineSearches($mzIndices, $indices);
+  
   $ally = &GetAllies($player);
   $indices = "";
   for($i=0; $i<count($ally); $i+=AllyPieces()) {

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -1262,6 +1262,7 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
         case "MYAURAS": $damage = AuraTakeDamageAbility($player, intval($mzIndex[1]), $params[0], $params[1]); break;
         case "MYCHAR": $damage = CharacterTakeDamageAbility($player, intval($mzIndex[1]), $params[0], $params[1]); break;
         case "MYALLY": $damage = AllyTakeDamageAbilities($player, intval($mzIndex[1]), $params[0], $params[1]); break;
+        case "MYITEMS": $damage = ItemTakeDamageAbilities($player, $params[0], "", $params[1], true); break;
         default: break;
       }
       if($damage < 0) $damage = 0;

--- a/ItemAbilities.php
+++ b/ItemAbilities.php
@@ -199,8 +199,8 @@ function ItemTakeDamageAbilities($player, $damage, $type="", $preventable=true, 
         if($items[$i+1] <= 0) DestroyItemForPlayer($player, $i);
         break;
       default:
-        if($isWard && $preventable) {
-          $damage -= ItemDamagePeventionAmount($player, $i);
+        if($isWard) {
+          if($preventable) $damage -= ItemDamagePeventionAmount($player, $i);
           DestroyItemForPlayer($player, $i);
         }
     }


### PR DESCRIPTION
`ItemTakeDamageAbilities` runs before the `PROCESSDAMAGEPREVENTION` decision queue that's why the `isWard` parameter exists. Also the `preventable` parameter is added as `PROCESSDAMAGEPREVENTION` already has that variable.
The items should work as intended however there could be something I overlooked. I haven't tested the item with Dash I/O hero ability.