### PR TITLE
Changes from Banned & Suspended Announcement, 27th November 2023

### DIFF
--- a/APIs/JoinGame.php
+++ b/APIs/JoinGame.php
@@ -666,6 +666,7 @@ function IsCardBanned($cardID, $format)
         case "ELE031": case "ELE034": // Lexi, Livewire | Voltaire, Strike Twice
         case "ELE062": case "ELE222": // Briar, Warden of Thorns | Rosetta Thorn
         case "ELE001": case "ELE003": // Oldhim, Grandfather of Eternity | Winter's Wail
+        case "UPR102": case "EVR121": // Iyslander, Stormbind | Kraken's Aethervein
           return true;
         default: return false;
       }

--- a/JoinGameInput.php
+++ b/JoinGameInput.php
@@ -663,6 +663,7 @@ function IsBanned($cardID, $format)
         case "ELE223": // Duskblade
         case "EVR017": // Bravo, Star of the Show
         case "UPR139": // Hypothermia
+        case "UPR102": case "EVR121": // Iyslander, Stormbind | Kraken's Aethervein
           return true;
         default:
           return false;


### PR DESCRIPTION
⚠️ Do not merge this PR before `Friday, December 1st 2023` as this is when the new policy will take effect.

### Description:
As per the <Announcement TBD>, the following cards have changed status

**Classic Constructed:**
- `UPR102` - Iyslander, Stormbind (Attained Living Legend status, `Legal` -> `Banned`)
- `EVR121` - Kraken's Aethervein (Signature Weapon policy, `Legal` -> `Banned`)