### PR TITLE
HVY249: Judge, Jury, Executioner Implementation

### DIFF
--- a/CardDictionaries/HitEffects.php
+++ b/CardDictionaries/HitEffects.php
@@ -103,7 +103,7 @@
     }
   }
 
-  function HVYHitEffect($cardID)
+function HVYHitEffect($cardID)
 {
   global $mainPlayer, $defPlayer;
   switch ($cardID) {

--- a/CardDictionaries/HitEffects.php
+++ b/CardDictionaries/HitEffects.php
@@ -103,4 +103,22 @@
     }
   }
 
+  function HVYHitEffect($cardID)
+{
+  global $mainPlayer, $defPlayer;
+  switch ($cardID) {
+    case "HVY249":
+      if (HasAimCounter() && IsHeroAttackTarget()) {
+        $defPlayerHand = &GetHand($defPlayer);
+        $defPlayerDiscardNum = count($defPlayerHand) - 1;
+        for ($i = 0; $i < $defPlayerDiscardNum; ++$i) {
+          PummelHit();
+        }
+        break;
+      }
+    default:
+      break;
+  }
+}
+
 ?>

--- a/CombatChain.php
+++ b/CombatChain.php
@@ -46,6 +46,7 @@ function ProcessHitEffect($cardID)
   else if($set == "DTD") return DTDHitEffect($cardID);
   else if($set == "TCC") return TCCHitEffect($cardID);
   else if($set == "EVO") return EVOHitEffect($cardID);
+  else if($set == "HVY") return HVYHitEffect($cardID);
 }
 
 function AttackModifier($cardID, $from = "", $resourcesPaid = 0, $repriseActive = -1)


### PR DESCRIPTION
**Description:**

Implementation of the new card `HVY249: Judge, Jury, Executioner`
Similar to other cards with discard effect for the opponent, Essentially `PummelHit()` X times where X is their hand size minus 1.
