### PR TITLE
Fixing Kayo interaction with Numbskull

### DIFF
--- a/CardDictionaries/CrucibleOfWar/CRUShared.php
+++ b/CardDictionaries/CrucibleOfWar/CRUShared.php
@@ -559,11 +559,11 @@ function CRUHitEffect($cardID)
   }
 }
 
-function KayoStaticAbility()
+function KayoStaticAbility($cardId)
 {
   global $combatChainState, $CCS_LinkBaseAttack, $mainPlayer;
   $roll = GetDieRoll($mainPlayer);
-  if($roll >= 5 && CanGainAttack()) $combatChainState[$CCS_LinkBaseAttack] *= 2;
+  if($roll >= 5 && CanGainAttack($cardId)) $combatChainState[$CCS_LinkBaseAttack] *= 2;
   else $combatChainState[$CCS_LinkBaseAttack] = floor($combatChainState[$CCS_LinkBaseAttack] / 2);
 }
 

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -1317,7 +1317,7 @@ function DestroyFrozenArsenal($player)
   }
 }
 
-function CanGainAttack()
+function CanGainAttack($cardID)
 {
   global $combatChain, $mainPlayer;
   if(SearchCurrentTurnEffects("OUT102", $mainPlayer)) return false;

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -10,7 +10,7 @@ function EvaluateCombatChain(&$totalAttack, &$totalDefense, &$attackModifiers=[]
   UpdateGameState($playerID);
   BuildMainPlayerGameState();
   $attackType = CardType($CombatChain->AttackCard()->ID());
-  $canGainAttack = CanGainAttack();
+  $canGainAttack = CanGainAttack($CombatChain->AttackCard()->ID());
   $snagActive = SearchCurrentTurnEffects("CRU182", $mainPlayer) && $attackType == "AA";
   $otherPlayer = ($mainPlayer == 1 ? 2 : 1);
   for($i=0; $i<$CombatChain->NumCardsActiveLink(); ++$i)

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -2078,7 +2078,7 @@ function PlayCardEffect($cardID, $from, $resourcesPaid, $target = "-", $addition
       if(EffectAttackRestricted()) return;
       $combatChainState[$CCS_AttackUniqueID] = $uniqueID;
       if($definedCardType == "AA" && $attackValue < 3) IncrementClassState($currentPlayer, $CS_NumLess3PowAAPlayed);
-      if($definedCardType == "AA" && (SearchCharacterActive($currentPlayer, "CRU002") || (SearchCharacterActive($currentPlayer, "CRU097") && SearchCurrentTurnEffects("CRU002-SHIYANA", $currentPlayer))) && $attackValue >= 6) KayoStaticAbility();
+      if($definedCardType == "AA" && (SearchCharacterActive($currentPlayer, "CRU002") || (SearchCharacterActive($currentPlayer, "CRU097") && SearchCurrentTurnEffects("CRU002-SHIYANA", $currentPlayer))) && $attackValue >= 6) KayoStaticAbility($cardID);
       $openedChain = true;
       if($definedCardType != "AA") $combatChainState[$CCS_WeaponIndex] = GetClassState($currentPlayer, $CS_PlayIndex);
       if($additionalCosts != "-" && HasFusion($cardID)) $combatChainState[$CCS_AttackFused] = 1;


### PR DESCRIPTION
**Description:**

`CRU002: Kayo`'s static effect should not be able to modify the attack power of `DTD201: Numbskull` 