### PR TITLE
Changes from Banned & Suspended Announcement, 4th December 2023

### DIFF
--- a/APIs/JoinGame.php
+++ b/APIs/JoinGame.php
@@ -646,6 +646,7 @@ function IsCardBanned($cardID, $format)
         case "MON154": case "MON155": // Chane | Galaxxi Black
         case "ARC114": case "ARC115": case "CRU159": // Kano | Crucible of Aetherweave
         case "CRU077": case "CRU079": case "CRU080": // Kassai, Cintari Sellsword | Cintari Saber
+        case "CRU046": case "CRU050": // Ira, Crimson Haze | Edge of Autumn
           return true;
         default: return false;
       }

--- a/JoinGameInput.php
+++ b/JoinGameInput.php
@@ -640,6 +640,7 @@ function IsBanned($cardID, $format)
         case "ELE002": case "ELE003": // Oldhim | Winter's Wail
         case "ARC114": case "ARC115": case "CRU159": // Kano | Crucible of Aetherweave
         case "CRU077": case "CRU079": case "CRU080": // Kassai, Cintari Sellsword | Cintari Saber
+        case "CRU046": case "CRU050": // Ira, Crimson Haze | Edge of Autumn
           return true;
         default:
           return false;


### PR DESCRIPTION
⚠️ Do not merge this PR before Friday, 4th December 2023 as this is when the new policy will take effect.
Description:

As per the [<Announcement TBC>](https://fabtcg.com/articles/), the following cards have changed status

Blitz:
`CRU046` - Ira, Crimson Haze (Attained Living Legend status, Legal -> Banned)
`CRU050` - Edge of Autumn (Signature Weapon policy, Legal -> Banned)