### PR TITLE
implement Graven Call

### DIFF
--- a/CardDictionaries/ActivatedAbilities.php
+++ b/CardDictionaries/ActivatedAbilities.php
@@ -6,14 +6,18 @@
     {
       case "HVY090": case "HVY091": return 0;
       case "HVY134": return 1;
+      case "HVY245": return 2;
       default: return 0;
     }
   }
 
-  function HVYAbilityType($cardID, $index=-1)
+  function HVYAbilityType($cardID, $index=-1, $from="-")
   {
     switch($cardID)
     {
+      case "HVY245":
+        if ($from == "GY") return "I";
+        else return "AA";
       case "HVY090": case "HVY091": return "A";
       case "HVY134": return "AA";
       default: return "";

--- a/CardDictionaries/PlayAbilities.php
+++ b/CardDictionaries/PlayAbilities.php
@@ -49,6 +49,20 @@
         AddDecisionQueue("SHUFFLEDECK", $currentPlayer, "-", 1);
         Reload();
         return "";
+      case "HVY245":
+        if($from == "GY") {
+          $character = &GetPlayerCharacter($currentPlayer);
+          EquipWeapon($currentPlayer,"HVY245");
+          $index = FindCharacterIndex($currentPlayer, "HVY245");
+          if ($character[$index + 3] == 0) {
+            ++$character[$index + 3];
+          } else {
+            ++$character[$index + 15];
+          }
+          $index = SearchGetFirstIndex(SearchMultizone($currentPlayer, "MYDISCARD:cardID=HVY245"));
+          RemoveGraveyard($currentPlayer, $index);
+        }
+        return "";
       default: return "";
     }
   }

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -421,7 +421,7 @@ function GetAbilityType($cardID, $index = -1, $from="-")
   else if($set == "DTD") return DTDAbilityType($cardID, $index);
   else if($set == "TCC") return TCCAbilityType($cardID, $index);
   else if($set == "EVO") return EVOAbilityType($cardID, $index);
-  else if($set == "HVY") return HVYAbilityType($cardID, $index);
+  else if($set == "HVY") return HVYAbilityType($cardID, $index, $from);
   else if($set == "ROG") return ROGUEAbilityType($cardID, $index);
 }
 
@@ -494,6 +494,7 @@ function IsPlayable($cardID, $phase, $from, $index = -1, &$restriction = null, $
   $character = &GetPlayerCharacter($player);
   $myHand = &GetHand($player);
   $banish = new Banish($player);
+  $grave = &GetDiscard($currentPlayer);
   $restriction = "";
   $cardType = CardType($cardID);
   $subtype = CardSubType($cardID);
@@ -503,6 +504,12 @@ function IsPlayable($cardID, $phase, $from, $index = -1, &$restriction = null, $
   if($from == "BANISH") {
     $banishCard = $banish->Card($index);
     if(!(PlayableFromBanish($banishCard->ID(), $banishCard->Modifier()) || AbilityPlayableFromBanish($banishCard->ID()))) return false;
+  }
+  if($from == "GY") {
+    $graveyardCard = $grave[$index];
+    if(!PlayableFromGraveyard($graveyardCard)) {
+      return false;
+    }
   }
   if($from == "DECK" && ($character[5] == 0 || $character[1] < 2 || $character[0] != "EVO001" && $character[0] != "EVO002" || CardCost($cardID) > 1 || !SubtypeContains($cardID, "Item", $player) || !ClassContains($cardID, "MECHANOLOGIST", $player))) return false;
   if($phase == "B") {
@@ -907,6 +914,7 @@ function IsPlayRestricted($cardID, &$restriction, $from = "", $index = -1, $play
     case "EVO434": case "EVO435": case "EVO436": case "EVO437": return !EvoHasUnderCard($currentPlayer, $index);
     case "HVY090": case "HVY091": return SearchCount(SearchDiscard($currentPlayer, pitch:1)) < 2 || SearchCount(SearchDiscard($currentPlayer, pitch:2)) < 2;
     case "HVY134": return GetClassState($player, $CS_AtksWWeapon) <= 0;
+    case "HVY245": if ($from == "GY") return CountItem("EVR195", $currentPlayer) < 2; else return false;
     default: return false;
   }
 }
@@ -1461,6 +1469,14 @@ function AbilityPlayableFromBanish($cardID)
   global $currentPlayer, $mainPlayer;
   switch($cardID) {
     case "MON192": return $currentPlayer == $mainPlayer;
+    default: return false;
+  }
+}
+
+function PlayableFromGraveyard($cardID)
+{
+  switch($cardID) {
+    case "HVY245": return true;
     default: return false;
   }
 }

--- a/CombatChain.php
+++ b/CombatChain.php
@@ -134,6 +134,7 @@ function AttackModifier($cardID, $from = "", $resourcesPaid = 0, $repriseActive 
     case "OUT005": case "OUT006": return NumEquipBlock() > 0 ? 1 : 0;
     case "OUT007": case "OUT008": return NumEquipBlock() > 0 ? 1 : 0;
     case "OUT009": case "OUT010": return NumEquipBlock() > 0 ? 1 : 0;
+    case "HVT245": return NumEquipBlock() > 0 ? 1 : 0;
     case "OUT018": case "OUT019": case "OUT020": return (NumAttackReactionsPlayed() > 0 ? 4 : 0);
     case "OUT051": return (ComboActive() ? 2 : 0);
     case "OUT054": return 1;

--- a/CurrentEffectAbilities.php
+++ b/CurrentEffectAbilities.php
@@ -344,6 +344,7 @@ function EffectHasBlockModifier($cardID)
     case "DTD094": case "DTD095": case "DTD096":
     case "TCC035":
     case "HVY202": case "HVY203": case "HVY204": case "HVY205": case "HVY206":
+    case "HVY245":
     return true;
     default: return false;
   }

--- a/GeneratedCode/DatabaseGeneratedCardDictionaries.php
+++ b/GeneratedCode/DatabaseGeneratedCardDictionaries.php
@@ -1209,6 +1209,12 @@ default: return false;
 }
 case "2":
 switch($cardID[4]) {
+case "4":
+switch($cardID[5]) {
+case "5":
+return true;
+default: return false;
+}
 case "5":
 switch($cardID[5]) {
 case "3":

--- a/GetNextTurn3.php
+++ b/GetNextTurn3.php
@@ -432,7 +432,9 @@ if ($lastUpdate != 0 && $cacheVal <= $lastUpdate) {
 
   $playerDiscardArr = array();
   for ($i = 0; $i < count($myDiscard); $i += DiscardPieces()) {
-    array_push($playerDiscardArr, JSONRenderedCard($myDiscard[$i]));
+    $action = $currentPlayer == $playerID && IsPlayable($myDiscard[$i], $turn[0], "GY", $i) ? 36 : 0;
+    $border = CardBorderColor($myDiscard[$i], "GY", $playable);
+    array_push($playerDiscardArr, JSONRenderedCard($myDiscard[$i], action: $action, borderColor: $border, actionDataOverride: strval($i)));
   }
   $response->playerDiscard = $playerDiscardArr;
 

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -426,6 +426,21 @@ function ProcessInput($playerID, $mode, $buttonInput, $cardID, $chkCount, $chkIn
       $deck = array_values($deck);
       PlayCard($cardID, "DECK");
       break;
+    case 36: //Play card from deck
+      $index = $cardID;
+      $grave = &GetDiscard($playerID);
+      $theirChar = &GetPlayerCharacter($playerID == 1 ? 2 : 1);
+      if($index < 0 || $index >= count($grave)) {
+        echo("Graveyard Index " . $index . " Invalid Input<BR>");
+        return false;
+      }
+      $cardID = $grave[$index];
+      if(!IsPlayable($cardID, $turn[0], "GY", $index)) break;
+      if($grave[$index + 1] == "INST") SetClassState($currentPlayer, $CS_NextNAAInstant, 1);
+      SetClassState($currentPlayer, $CS_PlayIndex, $index);
+      if(CanPlayAsInstant($cardID, $index, "GY")) SetClassState($currentPlayer, $CS_PlayedAsInstant, "1");
+      PlayCard($cardID, "GY", -1, $index, $grave[$index + 2]);
+      break;
     case 99: //Pass
       if(CanPassPhase($turn[0])) {
         PassInput(false);
@@ -2042,6 +2057,12 @@ function PayAdditionalCosts($cardID, $from)
       AddDecisionQueue("FINDANDDESTROYITEM", $currentPlayer, "<-");
       AddDecisionQueue("LASTRESULTPIECE", $currentPlayer, "1", 1);
       AddDecisionQueue("SETCLASSSTATE", $currentPlayer, $CS_AdditionalCosts, 1);
+      break;
+    case "HVY245":
+      if($from == "GY") {
+        AddDecisionQueue("PASSPARAMETER", $currentPlayer, "EVR195-2", 1);
+        AddDecisionQueue("FINDANDDESTROYITEM", $currentPlayer, "<-", 1);
+      }
       break;
     default:
       break;

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -426,7 +426,7 @@ function ProcessInput($playerID, $mode, $buttonInput, $cardID, $chkCount, $chkIn
       $deck = array_values($deck);
       PlayCard($cardID, "DECK");
       break;
-    case 36: //Play card from deck
+    case 36: //Play card from graveyard
       $index = $cardID;
       $grave = &GetDiscard($playerID);
       $theirChar = &GetPlayerCharacter($playerID == 1 ? 2 : 1);

--- a/Libraries/UILibraries2.php
+++ b/Libraries/UILibraries2.php
@@ -755,6 +755,10 @@ function CardBorderColor($cardID, $from, $isPlayable, $mod = "-")
     if ($isPlayable && HasRupture($cardID) && RuptureActive(true)) return 5;
     return 0;
   }
+  if ($from == "GY") {
+    if ($isPlayable || PlayableFromGraveyard($cardID, $mod)) return 7;
+    return 0;
+  }
   if ($isPlayable && ComboActive($cardID)) return 3;
   if ($isPlayable && HasReprise($cardID) && RepriseActive()) return 3;
   if ($isPlayable && HasRupture($cardID) && RuptureActive(true, (CardType($cardID) != "AA"))) return 3;


### PR DESCRIPTION
Add support for graven call.

took a stab at adding this myself. Tried to follow existing patterns for cards that have different abilities in different zones (like guardian of the shadowrealm).

Small visual bug in this change, counters aren't removed from the weapon zone when the weapon is destroyed, but this doesn't functionally affect you when you equip subsequent weapons in that zone.

also I was not able to update GeneratedCardDictionaries.php, which specifies card subtypes for things like concealed blade

You will need to add this front end PR to go along with this change https://github.com/Talishar/Talishar-FE/pull/460

