### PR TITLE
Fix Tarpit + Main Character Triggers

### DIFF
--- a/CardDictionaries/Keywords.php
+++ b/CardDictionaries/Keywords.php
@@ -41,8 +41,10 @@
 
   function ProcessTowerEffect($cardID)
   {
-    global $CombatChain, $mainPlayer;
+    global $CombatChain, $mainPlayer, $layers;
     if(!IsHeroAttackTarget()) return;
+    if(HitEffectsArePrevented($cardID)) return;
+    if(SearchCurrentTurnEffects("OUT108", $mainPlayer, count($layers) <= LayerPieces())) return true;
     switch($cardID)
     {
       case "TCC034": case "HVY062":

--- a/CardDictionaries/WelcomeToRathe/WTRShared.php
+++ b/CardDictionaries/WelcomeToRathe/WTRShared.php
@@ -553,10 +553,11 @@
 
   function ProcessCrushEffect($cardID)
   {
-    global $mainPlayer, $defPlayer, $defCharacter, $CombatChain, $combatChainState, $CCS_DamageDealt;
-    if(CardType($CombatChain->AttackCard()->ID()) == "AA" && (SearchAuras("CRU028", 1) || SearchAuras("CRU028", 2))) return;
+    global $mainPlayer, $defPlayer, $defCharacter, $CombatChain, $combatChainState, $CCS_DamageDealt, $layers;
     if(!IsHeroAttackTarget()) return;
-    switch($cardID) {
+    if(HitEffectsArePrevented($CombatChain->AttackCard()->ID())) return;
+    if(SearchCurrentTurnEffects("OUT108", $mainPlayer, count($layers) <= LayerPieces())) return true;
+      switch($cardID) {
       case "WTR043":
         DiscardRandom($defPlayer, $cardID, $mainPlayer);
         DiscardRandom($defPlayer, $cardID, $mainPlayer);

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -708,6 +708,75 @@ function AddEffectHitTrigger($cardID)
   }
 }
 
+function ProcessMainCharacterHitEffect($cardID, $player, $target) {
+  global $combatChain, $mainPlayer, $layers;
+  $character = &GetPlayerCharacter($player);
+  WriteLog(count($layers) . "<=" . LayerPieces());
+  if(CardType($target) == "AA" && SearchCurrentTurnEffects("OUT108", $mainPlayer, count($layers) <= LayerPieces())) return true;
+  switch ($cardID) {
+    case "WTR076": case "WTR077":
+      KatsuHit();
+      break;
+    case "WTR117":
+      $index = FindCharacterIndex($player, $cardID);
+      AddDecisionQueue("YESNO", $player, "if_you_want_to_destroy_Refraction_Bolters_to_get_Go_Again");
+      AddDecisionQueue("NOPASS", $player, "-", 1);
+      AddDecisionQueue("PASSPARAMETER", $player, "MYCHAR-$index", 1);
+      AddDecisionQueue("MZDESTROY", $player, "-", 1);
+      AddDecisionQueue("OP", $player, "GIVEATTACKGOAGAIN", 1);
+      AddDecisionQueue("WRITELOG", $player, "Refraction Bolters was destroyed", 1);
+      break;
+    case "WTR079":
+      Draw($player);
+      break;
+    case "ARC152":
+      $index = FindCharacterIndex($player, $cardID);
+      AddDecisionQueue("YESNO", $player, "if_you_want_to_destroy_Vest_of_the_First_Fist_to_gain_2_resources");
+      AddDecisionQueue("NOPASS", $player, "");
+      AddDecisionQueue("PASSPARAMETER", $player, "MYCHAR-" . $index, 1);
+      AddDecisionQueue("MZDESTROY", $player, "-", 1);
+      AddDecisionQueue("GAINRESOURCES", $player, 2, 1);
+      break;
+    case "CRU053":
+      $index = FindCharacterIndex($player, $cardID);
+      AddDecisionQueue("YESNO", $player, "if_you_want_to_destroy_Breeze_Rider_Boots");
+      AddDecisionQueue("NOPASS", $player, "-");
+      AddDecisionQueue("PASSPARAMETER", $player, $index, 1);
+      AddDecisionQueue("DESTROYCHARACTER", $player, "-", 1);
+      AddDecisionQueue("ADDCURRENTEFFECT", $player, $character[$index], 1);
+      break;
+    case "EVR037":
+      $index = FindCharacterIndex($player, $cardID);
+      AddDecisionQueue("YESNO", $player, "to_destroy_Mask_of_the_Pouncing_Lynx");
+      AddDecisionQueue("NOPASS", $player, "-");
+      AddDecisionQueue("PASSPARAMETER", $player, $index, 1);
+      AddDecisionQueue("DESTROYCHARACTER", $player, "-", 1);
+      AddDecisionQueue("FINDINDICES", $player, "MASKPOUNCINGLYNX", 1);
+      AddDecisionQueue("MAYCHOOSEDECK", $player, "<-", 1);
+      AddDecisionQueue("MULTIBANISH", $player, "DECK,TT", 1);
+      AddDecisionQueue("SETDQVAR", $player, "0", 1);
+      AddDecisionQueue("WRITELOG", $player, "<0> was banished", 1);
+      AddDecisionQueue("SHUFFLEDECK", $player, "-", 1);
+      break;
+    case "HVY097":
+      $hand = &GetHand($player);
+      $resources = &GetResources($player);
+      if(CardType($combatChain[0]) == "W" && (Count($hand) > 0 || $resources[0] > 0))
+      {
+        AddDecisionQueue("YESNO", $player, "if you want to pay 1 to create a " . CardLink("HVY242", "HVY242"), 0, 1);
+        AddDecisionQueue("NOPASS", $player, "-", 1);
+        AddDecisionQueue("PASSPARAMETER", $player, "1", 1);
+        AddDecisionQueue("PAYRESOURCES", $player, "<-", 1);
+        AddDecisionQueue("WRITELOG", $player, "🩸 " . CardLink($cardID, $cardID) . " created a " . CardLink("HVY242", "HVY242") . " token ", 1);
+        AddDecisionQueue("PASSPARAMETER", $player, "HVY242", 1);
+        AddDecisionQueue("PUTPLAY", $player, "-", 1);
+      }
+      break;
+    default:
+      break;
+  }
+}
+
 function ProcessTrigger($player, $parameter, $uniqueID, $target="-", $additionalCosts="-")
 {
   global $combatChain, $CS_NumNonAttackCards, $CS_ArcaneDamageDealt, $CS_NumRedPlayed, $CS_DamageTaken, $EffectContext, $CS_PlayIndex;
@@ -726,6 +795,8 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target="-", $additional
     if($shouldRemove == 1) RemoveCurrentTurnEffect(FindCurrentTurnEffectIndex($player, $target));
     return;
   }
+  if($additionalCosts == "MAINCHARHITEFFECT")  { ProcessMainCharacterHitEffect($parameter, $player, $target); return; }
+
   switch($parameter) {
     case "HEAVE":
       Heave();
@@ -761,21 +832,6 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target="-", $additional
       AddCurrentTurnEffect($parameter, $player);
       DestroyAuraUniqueID($player, $uniqueID);
       break;
-    case "WTR076": case "WTR077":
-      KatsuHit();
-      break;
-    case "WTR079":
-      Draw($player);
-      break;
-    case "WTR117":
-      $index = FindCharacterIndex($player, $parameter);
-      AddDecisionQueue("YESNO", $player, "if_you_want_to_destroy_Refraction_Bolters_to_get_Go_Again");
-      AddDecisionQueue("NOPASS", $player, "-", 1);
-      AddDecisionQueue("PASSPARAMETER", $player, "MYCHAR-$index", 1);
-      AddDecisionQueue("MZDESTROY", $player, "-", 1);
-      AddDecisionQueue("OP", $player, "GIVEATTACKGOAGAIN", 1);
-      AddDecisionQueue("WRITELOG", $player, "Refraction Bolters was destroyed", 1);
-      break;
     case "WTR119":
       Draw($mainPlayer);
       break;
@@ -808,14 +864,6 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target="-", $additional
       DealArcane(1, 1, "RUNECHANT", "ARC112", player:$player);
       DestroyAuraUniqueID($player, $uniqueID);
       break;
-    case "ARC152":
-      $index = FindCharacterIndex($player, $parameter);
-      AddDecisionQueue("YESNO", $player, "if_you_want_to_destroy_Vest_of_the_First_Fist_to_gain_2_resources");
-      AddDecisionQueue("NOPASS", $player, "");
-      AddDecisionQueue("PASSPARAMETER", $player, "MYCHAR-" . $index, 1);
-      AddDecisionQueue("MZDESTROY", $player, "-", 1);
-      AddDecisionQueue("GAINRESOURCES", $player, 2, 1);
-      break;
     case "ARC162":
       DestroyAuraUniqueID($player, $uniqueID);
       break;
@@ -846,14 +894,6 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target="-", $additional
           DestroyCurrentWeapon();
         }
       }
-      break;
-    case "CRU053":
-      $index = FindCharacterIndex($player, $parameter);
-      AddDecisionQueue("YESNO", $player, "if_you_want_to_destroy_Breeze_Rider_Boots");
-      AddDecisionQueue("NOPASS", $player, "-");
-      AddDecisionQueue("PASSPARAMETER", $player, $index, 1);
-      AddDecisionQueue("DESTROYCHARACTER", $player, "-", 1);
-      AddDecisionQueue("ADDCURRENTEFFECT", $player, $character[$index], 1);
       break;
     case "CRU075":
       $index = SearchAurasForUniqueID($uniqueID, $player);
@@ -989,19 +1029,6 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target="-", $additional
     case "EVR018":
       PlayAura("ELE111", $player);
       break;
-    case "EVR037":
-      $index = FindCharacterIndex($player, $parameter);
-      AddDecisionQueue("YESNO", $player, "to_destroy_Mask_of_the_Pouncing_Lynx");
-      AddDecisionQueue("NOPASS", $player, "-");
-      AddDecisionQueue("PASSPARAMETER", $player, $index, 1);
-      AddDecisionQueue("DESTROYCHARACTER", $player, "-", 1);
-      AddDecisionQueue("FINDINDICES", $player, "MASKPOUNCINGLYNX", 1);
-      AddDecisionQueue("MAYCHOOSEDECK", $player, "<-", 1);
-      AddDecisionQueue("MULTIBANISH", $player, "DECK,TT", 1);
-      AddDecisionQueue("SETDQVAR", $player, "0", 1);
-      AddDecisionQueue("WRITELOG", $player, "<0> was banished", 1);
-      AddDecisionQueue("SHUFFLEDECK", $player, "-", 1);
-      break;
     case "EVR069":
       $index = SearchItemsForUniqueID($uniqueID, $player);
       --$items[$index+1];
@@ -1018,20 +1045,6 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target="-", $additional
         DestroyItemForPlayer($player, $index);
         WriteLog(CardLink($items[$index], $items[$index]) . " was destroyed");
       }      
-      break;
-    case "HVY097":
-      $hand = &GetHand($player);
-      $resources = &GetResources($player);
-      if(CardType($combatChain[0]) == "W" && (Count($hand) > 0 || $resources[0] > 0))
-      {
-        AddDecisionQueue("YESNO", $player, "if you want to pay 1 to create a " . CardLink("HVY242", "HVY242"), 0, 1);
-        AddDecisionQueue("NOPASS", $player, "-", 1);
-        AddDecisionQueue("PASSPARAMETER", $player, "1", 1);
-        AddDecisionQueue("PAYRESOURCES", $player, "<-", 1);
-        AddDecisionQueue("WRITELOG", $player, "🩸 " . CardLink($parameter, $parameter) . " created a " . CardLink("HVY242", "HVY242") . " token ", 1);
-        AddDecisionQueue("PASSPARAMETER", $player, "HVY242", 1);
-        AddDecisionQueue("PUTPLAY", $player, "-", 1);
-      }
       break;
     case "EVR107": case "EVR108": case "EVR109":
       $index = SearchAurasForUniqueID($uniqueID, $player);

--- a/CharacterAbilities.php
+++ b/CharacterAbilities.php
@@ -353,7 +353,7 @@ function MainCharacterEndTurnAbilities()
   }
 }
 
-function MainCharacterHitAbilities()
+function MainCharacterHitTrigger()
 {
   global $CombatChain, $combatChainState, $CCS_WeaponIndex, $mainPlayer;
   $attackID = $CombatChain->AttackCard()->ID();
@@ -364,13 +364,13 @@ function MainCharacterHitAbilities()
     switch($characterID) {
       case "WTR076": case "WTR077":
         if(CardType($attackID) == "AA") {
-          AddLayer("TRIGGER", $mainPlayer, $characterID);
+          AddLayer("TRIGGER", $mainPlayer, $characterID, $attackID, "MAINCHARHITEFFECT");
           $mainCharacter[$i+1] = 1;
         }
         break;
       case "WTR079":
         if(CardType($attackID) == "AA" && HitsInRow() >= 2) {
-          AddLayer("TRIGGER", $mainPlayer, $characterID);
+          AddLayer("TRIGGER", $mainPlayer, $characterID, $attackID, "MAINCHARHITEFFECT");
           $mainCharacter[$i+1] = 1;
         }
         break;
@@ -383,12 +383,12 @@ function MainCharacterHitAbilities()
         break;
       case "WTR117":
         if(CardType($attackID) == "W" && IsCharacterActive($mainPlayer, $i)) {
-          AddLayer("TRIGGER", $mainPlayer, $characterID);
+          AddLayer("TRIGGER", $mainPlayer, $characterID, $attackID, "MAINCHARHITEFFECT");
         }
         break;
       case "ARC152":
         if(CardType($attackID) == "AA" && IsCharacterActive($mainPlayer, $i)) {
-          AddLayer("TRIGGER", $mainPlayer, $characterID);
+          AddLayer("TRIGGER", $mainPlayer, $characterID, $attackID, "MAINCHARHITEFFECT");
         }
         break;
       case "CRU047":
@@ -399,7 +399,7 @@ function MainCharacterHitAbilities()
         break;
       case "CRU053":
         if(CardType($attackID) == "AA" && ClassContains($attackID, "NINJA", $mainPlayer) && IsCharacterActive($mainPlayer, $i)) {
-          AddLayer("TRIGGER", $mainPlayer, $characterID);
+          AddLayer("TRIGGER", $mainPlayer, $characterID, $attackID, "MAINCHARHITEFFECT");
         }
         break;
       case "ELE062": case "ELE063":
@@ -409,13 +409,13 @@ function MainCharacterHitAbilities()
         break;
       case "EVR037":
         if(CardType($attackID) == "AA" && IsCharacterActive($mainPlayer, $i)) {
-          AddLayer("TRIGGER", $mainPlayer, $characterID);
+          AddLayer("TRIGGER", $mainPlayer, $characterID, $attackID, "MAINCHARHITEFFECT");
         }
         break;
       case "HVY097":
         if(CardType($attackID) == "W")
         {
-          AddLayer("TRIGGER", $mainPlayer, $characterID);
+          AddLayer("TRIGGER", $mainPlayer, $characterID, $attackID, "MAINCHARHITEFFECT");
         }
         break;
       case "ROGUE016":

--- a/CombatChain.php
+++ b/CombatChain.php
@@ -3,9 +3,9 @@
 function ProcessHitEffect($cardID)
 {
   WriteLog("Processing hit effect for " . CardLink($cardID, $cardID));
-  global $CombatChain;
-  if(CardType($CombatChain->AttackCard()->ID()) == "AA" && (SearchAuras("CRU028", 1) || SearchAuras("CRU028", 2))) return;
-  if(HitEffectsArePrevented()) return;
+  global $CombatChain, $layers, $mainPlayer;
+  if(HitEffectsArePrevented($CombatChain->AttackCard()->ID())) return;
+  if(SearchCurrentTurnEffects("OUT108", $mainPlayer, count($layers) <= LayerPieces())) return true;
   $cardID = ShiyanaCharacter($cardID);
   $set = CardSet($cardID);
   $class = CardClass($cardID);

--- a/Constants.php
+++ b/Constants.php
@@ -196,7 +196,7 @@ function ChainLinksPieces()
 //7 - Modal Play Ability - e.g. Enlightened Strike
 function ChainLinkSummaryPieces()
 {
-  return 7;
+  return 8;
 }
 
 function DecisionQueuePieces()

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -349,7 +349,6 @@ function DealDamageAsync($player, $damage, $type="DAMAGE", $source="NA")
 {
   global $CS_DamagePrevention, $combatChain, $CS_ArcaneDamagePrevention, $dqVars, $dqState;
   $classState = &GetPlayerClassState($player);
-  if($type == "COMBAT" && $damage > 0 && EffectPreventsHit()) HitEffectsPreventedThisLink();
   if($type == "COMBAT" || $type == "ATTACKHIT") $source = $combatChain[0];
   $otherPlayer = $player == 1 ? 2 : 1;
   $damage = $damage > 0 ? $damage : 0;
@@ -546,7 +545,7 @@ function CurrentEffectDamageEffects($target, $source, $type, $damage)
   for($i=count($currentTurnEffects)-CurrentTurnPieces(); $i >= 0; $i-=CurrentTurnPieces())
   {
     if($currentTurnEffects[$i+1] == $target) { continue; }
-    if($type == "COMBAT" && HitEffectsArePrevented()) continue;
+    if($type == "COMBAT" && HitEffectsArePrevented($source)) continue;
     $remove = 0;
     switch($currentTurnEffects[$i])
     {
@@ -1917,9 +1916,10 @@ function HasAttackName($name)
   return false;
 }
 
-function HitEffectsArePrevented()
+function HitEffectsArePrevented($cardID)
 {
   global $combatChainState, $CCS_ChainLinkHitEffectsPrevented;
+  if(CardType($cardID) == "AA" && (SearchAuras("CRU028", 1) || SearchAuras("CRU028", 2))) return true;
   return $combatChainState[$CCS_ChainLinkHitEffectsPrevented];
 }
 
@@ -1927,24 +1927,6 @@ function HitEffectsPreventedThisLink()
 {
   global $combatChainState, $CCS_ChainLinkHitEffectsPrevented;
   $combatChainState[$CCS_ChainLinkHitEffectsPrevented] = 1;
-}
-
-function EffectPreventsHit()
-{
-  global $currentTurnEffects, $mainPlayer, $combatChain;
-  $preventsHit = false;
-  for($i=count($currentTurnEffects)-CurrentTurnPieces(); $i >= 0; $i-=CurrentTurnPieces())
-  {
-    if($currentTurnEffects[$i+1] != $mainPlayer) continue;
-    $remove = 0;
-    switch($currentTurnEffects[$i])
-    {
-      case "OUT108": if(CardType($combatChain[0]) == "AA") { $preventsHit = true; $remove = 1; } break;
-      default: break;
-    }
-    if($remove == 1) RemoveCurrentTurnEffect($i);
-  }
-  return $preventsHit;
 }
 
 function HitsInRow()

--- a/CurrentEffectAbilities.php
+++ b/CurrentEffectAbilities.php
@@ -5,9 +5,10 @@
 function EffectHitEffect($cardID)
 {
   global $combatChainState, $CCS_GoesWhereAfterLinkResolves, $defPlayer, $mainPlayer, $CCS_WeaponIndex, $CombatChain, $CCS_DamageDealt;
-  global $CID_BloodRotPox, $CID_Frailty, $CID_Inertia, $Card_LifeBanner, $Card_ResourceBanner;
+  global $CID_BloodRotPox, $CID_Frailty, $CID_Inertia, $Card_LifeBanner, $Card_ResourceBanner, $layers;
   $attackID = $CombatChain->AttackCard()->ID();
-  if(CardType($attackID) == "AA" && (SearchAuras("CRU028", 1) || SearchAuras("CRU028", 2))) return;
+  if(HitEffectsArePrevented($attackID)) return;
+  if(SearchCurrentTurnEffects("OUT108", $mainPlayer, count($layers) <= LayerPieces())) return true;
   $effectArr = explode(",", $cardID);
   $cardID = $effectArr[0];
   switch($cardID) {

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -989,7 +989,7 @@ function ResolveCombatDamage($damageDone)
       IncrementClassState($mainPlayer, $CS_HitsWithWeapon);
       if(SubtypeContains($combatChain[0], "Sword", $mainPlayer)) IncrementClassState($mainPlayer, $CS_HitsWithSword);
     }
-    if(!HitEffectsArePrevented()) {
+    if(!HitEffectsArePrevented($combatChain[0])) {
       for($i = 1; $i < count($combatChain); $i += CombatChainPieces()) {
         if($combatChain[$i] == $mainPlayer) {
           $EffectContext = $combatChain[$i - 1];
@@ -1007,7 +1007,7 @@ function ResolveCombatDamage($damageDone)
         }
       }
       $currentTurnEffects = array_values($currentTurnEffects);
-      MainCharacterHitAbilities();
+      MainCharacterHitTrigger();
       MainCharacterHitEffects();
       ArsenalHitEffects();
       AuraHitEffects($combatChain[0]);


### PR DESCRIPTION
Many things in this commit, and I wanted to write a resume to help with the reviewing job. I made those change to fix this issue from Outsiders. Where Tarpit should use Katsu, Mask of Momentum, etc. uses but simply cancel the triggers. https://github.com/Talishar/Talishar/issues/586

- I had to code the MainCharacterHitAbilities() has triggers like we previously did for all on-hit triggers using "MAINCHARHITEFFECT" on their layer.
- I moved all Main Character Hit Abilities from ProcessTrigger() Switch Case to their own function, ProcessMainCharacterHitEffect. I think on the long term, we have to split all those triggers to clean this big switch case. This was done so Tarpit only stop triggers that matter. I did not want it to affect discard, allies triggers, etc. that are all in the Switch Case.
- Move Stamp Authority condition into HitEffectsArePrevented() function. It was repetitive and it's now cleaner.
- Keywords.php > ProcessTowerEffect > Added old HitEffectsArePrevented() and new condition for Tarpit. It was missing from Tower Effect
- WTRShared.php > ProcessCrushEffect > Added old HitEffectsArePrevented() and new condition for Tarpit. It was missing from Tower Effect. 
- CurrentEffectAbilities > EffectHitEffect > Added old HitEffectsArePrevented() and new condition for Tarpit. It was missing from Tower Effect
- CombatChain > ProcessHitEffect > Added new Tarpit Condition.

I hope this clear things out and help :)