### PR TITLE
Better handling of modular equipments

### DIFF
--- a/APIs/GetLobbyInfo.php
+++ b/APIs/GetLobbyInfo.php
@@ -101,6 +101,7 @@ if($handler) {
     else if (SubtypeContains($cardID, "Chest")) array_push($response->deck->chest, $cardID);
     else if (SubtypeContains($cardID, "Arms")) array_push($response->deck->arms, $cardID);
     else if (SubtypeContains($cardID, "Legs")) array_push($response->deck->legs, $cardID);
+    else if (IsModular($cardID)) array_push($response->deck->modular, $cardID);
     else {
       $handItem = new stdClass();
       $handItem->id = $cardID;
@@ -162,6 +163,8 @@ if($handler) {
     $handItem->is1H = Is1H($handItem->id);
     array_push($response->deck->handsSB, $handItem);
   }
+
+  $response->deck->modular = GetArray($handler);
 
   $cardIndex = [];
   $response->deck->cardDictionary = [];

--- a/APIs/JoinGame.php
+++ b/APIs/JoinGame.php
@@ -188,6 +188,7 @@ if ($decklink != "") {
   $legsSideboard = "";
   $offhandSideboard = "";
   $quiverSideboard = "";
+  $modularSideboard = "";
   $unsupportedCards = "";
   $bannedCard = "";
   $character = "";
@@ -241,21 +242,19 @@ if ($decklink != "") {
         $bannedCard .= CardName($id);
       }
 
-      if ($cardType == "") //Card not supported, error
-      {
+      if ($cardType == "") { //Card not supported, error
         if ($unsupportedCards != "") $unsupportedCards .= " ";
         $unsupportedCards .= $id;
-      }
-      else if($id == "EVO013") {
-        ++$totalCards;
+      } else if (IsModular($id)) {
+        // The way we handle modular equipment, we force it to the sideboard,
+        // and it'll equipped straight from the inventory at start of game
         $numMainBoard = ($isFaBDB ? $count - $numSideboard : $count);
-        $count = $numMainBoard + $numSideboard;
-        for($j=0; $j<$count; ++$j) {
-          if ($legsSideboard != "") $legsSideboard .= " ";
-          $legsSideboard .= $id;
+        for($j=0; $j < $numMainBoard + $numSideboard; ++$j) {
+          if ($modularSideboard != "") $modularSideboard .= " ";
+          $modularSideboard .= $id;
         }
-      }
-      else if (TypeContains($id, "C")) {
+        $totalCards += $numMainBoard + $numSideboard;
+      } else if (TypeContains($id, "C")) {
         $character = $id;
       } else if (TypeContains($id, "W")) {
         ++$totalCards;
@@ -364,8 +363,7 @@ if ($decklink != "") {
     exit;
   }
 
-  if(($format == "sealed" || $format == "draft") && substr($decklink, 0, 9) != "DRAFTFAB-")
-  {
+  if(($format == "sealed" || $format == "draft") && substr($decklink, 0, 9) != "DRAFTFAB-") {
     //Currently must use draft fab for sealed/draft
     $response->error = "You must use a DraftFaB deck for " . $format . ".";
     echo json_encode($response);
@@ -429,7 +427,8 @@ if ($decklink != "") {
   fwrite($deckFile, $offhandSideboard . "\r\n");
   fwrite($deckFile, $weaponSideboard . "\r\n");
   fwrite($deckFile, $sideboardCards . "\r\n");
-  fwrite($deckFile, $quiverSideboard);
+  fwrite($deckFile, $quiverSideboard . "\r\n");
+  fwrite($deckFile, $modularSideboard);
   fclose($deckFile);
   copy($filename, "../Games/" . $gameName . "/p" . $playerID . "DeckOrig.txt");
 
@@ -685,8 +684,8 @@ function IsCardBanned($cardID, $format)
   if($format != "livinglegendscc" && ($set == "MST")) return true; // Launch 31st May
   if($format != "livinglegendscc" && ($set == "AKO")) return true; // Launch 3rd May
   switch ($cardID) { //Special Use Promos
-    case "JDG002": case "JDG004": case "JDG005": case "JDG008": case "JDG010": case "JDG019": case "JDG024": case "JDG025": 
-    case "LSS001": case "LSS002": case "LSS003": case "LSS004": case "LSS005": case "LSS006": case "LSS007": case "LSS008": 
+    case "JDG002": case "JDG004": case "JDG005": case "JDG008": case "JDG010": case "JDG019": case "JDG024": case "JDG025":
+    case "LSS001": case "LSS002": case "LSS003": case "LSS004": case "LSS005": case "LSS006": case "LSS007": case "LSS008":
     case "FAB094":
     case "LGS099":
     case "HER101":

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -749,8 +749,8 @@ function GoesWhereAfterResolving($cardID, $from = null, $player = "", $playedFro
         }
       }
       return "GY";
-    case "MST095": case "MST096": case "MST097": 
-    case "MST098": case "MST099": case "MST100": 
+    case "MST095": case "MST096": case "MST097":
+    case "MST098": case "MST099": case "MST100":
     case "MST101": case "MST102":
       if(GetClassState($currentPlayer, $CS_NumBluePlayed) > 1) return "-";
       else return "GY";
@@ -1953,6 +1953,14 @@ function CardCareAboutChiPitch($cardID)
       case "MST001": case "MST002": case "MST025":
       case "MST026": case "MST046": case "MST047":
       return true;
+    default: return false;
+  }
+}
+
+function IsModular($cardID)
+{
+  switch($cardID) {
+    case "EVO013": return true;
     default: return false;
   }
 }

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -1195,7 +1195,7 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
         RevertGamestate();
         return "PASS";
       }
-      return $lastResult;  
+      return $lastResult;
     case "PREPENDLASTRESULT":
       return $parameter . $lastResult;
     case "APPENDLASTRESULT":
@@ -1723,7 +1723,7 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
                 for($j = 0; $j < count($chainLinks[$i]); $j += ChainLinksPieces()) {
                   if($chainLinks[$i][$j] == $lastResult) $chainLinks[$i][$j+2] = 0;
                 }
-              }            
+              }
             }
             break;
         }
@@ -1759,6 +1759,15 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
         AddCurrentTurnEffect($params[0].$target, GetMZCard($mainPlayer, $params[1]."-".$lastResult+1), (count($params) > 1 ? $params[1] : ""));
         WriteLog(CardLink("EVR181", "EVR181") . " targetted " . CardLink($target, $target));
         return $lastResult;
+      case "LISTEMPTYEQUIPSLOTS":
+        $character = &GetPlayerCharacter($player);
+        $available = array_filter(["Head", "Chest", "Arms", "Legs"], function ($slot) use ($character) {
+          for ($i = 0; $i < count($character); $i += CharacterPieces()) {
+            if (SubtypeContains($character[$i], $slot)) return false;
+          }
+          return true;
+        });
+        return empty($available) ? "PASS" : implode(",", $available);
     default:
       return "NOTSTATIC";
   }

--- a/StartEffects.php
+++ b/StartEffects.php
@@ -165,18 +165,14 @@ function InventoryStartGameAbilities($player) {
         array_push($inventory, "DTD564");
         break;
       case "EVO013":
-        AddDecisionQueue("SETDQCONTEXT", $player, "Choose where to put " . CardLink($inventory[$i], $inventory[$i]) . " (one per prompt)", 1);
-        AddDecisionQueue("OK", $player, "-", 1);
-        AddDecisionQueue("MODAL", $player, "ADAPTIVEPLATING", 1);
-        AddDecisionQueue("SETDQCONTEXT", $player, "Choose where to equip your " . CardLink($inventory[$i], $inventory[$i]) );
-        AddDecisionQueue("MULTICHOOSETEXT", $player, "1-Head,Chest,Arms,Legs,None-1");
+        AddDecisionQueue("LISTEMPTYEQUIPSLOTS", $player, "-");
+        AddDecisionQueue("SETDQVAR", $player, "0", 1);
+        AddDecisionQueue("SETDQCONTEXT", $player, "Choose where to equip your " . CardLink($inventory[$i], $inventory[$i]) . " (one at a time)", 1);
+        AddDecisionQueue("BUTTONINPUT", $player, "{0},None", 1);
         AddDecisionQueue("MODAL", $player, "ADAPTIVEPLATING", 1);
         AddDecisionQueue("SHOWMODES", $player, "EVO013", 1);
         break;
       default: break;
     }
   }
-  if($player == 1) $p1Inventory = $inventory;
-  else $p2Inventory = $inventory;
 }
-


### PR DESCRIPTION
This pull request tries to improve the interface of modular equipments (well, the one) by making them their own categories at the sideboarding step, and by cleaning up to equip popups at the start of game. It pairs with a Talishar-FE PR (https://github.com/Talishar/Talishar-FE/pull/540) that handles the ui part of it.

It's currently marked as draft due to a few issues:
1. When you have more than one modular equipment, the goal was for the second one to be not be equipable in the slot you chose for the first one. I suspect this is due to a timing issue wrt to SubtypeContains which has specific handling for EVO013.

2. In some places I've tried for the code to be future proof and be generic over other modular equipments than EVO013, and in some place I've kind of given up. We should probably choose one of those options and make it consistent across the board.

3. Vscode's autoformatter really dislike trailing whitespaces. I felt like it wasn't too noisy and have lest them part of the commit in the files I've touched, but do tell if you'd rather have those restored.

When done, would fix/improve #788 
