### PR TITLE
Fix handling of multiple modular equipments

### DIFF
--- a/GameLogic.php
+++ b/GameLogic.php
@@ -1763,7 +1763,8 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
         $character = &GetPlayerCharacter($player);
         $available = array_filter(["Head", "Chest", "Arms", "Legs"], function ($slot) use ($character) {
           for ($i = 0; $i < count($character); $i += CharacterPieces()) {
-            if (SubtypeContains($character[$i], $slot)) return false;
+            $subtype = CardSubType($character[$i], $character[$i + 11]);
+            if (DelimStringContains($subtype, $slot)) return false;
           }
           return true;
         });


### PR DESCRIPTION
This is a small fix to https://github.com/Talishar/Talishar/pull/850 to better handle the case where you have multiple modular equipments, so that it doesn't propose a slot you just chose. This one doesn't interact with the FE at all.