### PR TITLE
fix: change wrong variable name on AddLayer call

### DIFF
--- a/CombatChain.php
+++ b/CombatChain.php
@@ -468,7 +468,7 @@ function OnBlockResolveEffects($cardID = "")
     }
     switch($defendingCard) {
       case "EVR018":
-        if(!IsAllyAttacking()) AddLayer("TRIGGER", $mainPlayer, $cardID);
+        if(!IsAllyAttacking()) AddLayer("TRIGGER", $mainPlayer, $defendingCard);
         else WriteLog("<span style='color:red;'>No frostbite is created because there is no attacking hero when allies attack.</span>");
         break;  
       case "MON241": case "MON242": case "MON243": case "MON244": case "RVD005": case "RVD006"://Ironhide


### PR DESCRIPTION
This fixes the bug report 6207689.
When blocking with Stalagmite, frostbite was not created. 

![image](https://github.com/Talishar/Talishar/assets/5968740/95542884-4f83-4071-b3d2-ae2b817a2f22)
