### PR TITLE
bugfix/azalea_card_fixes

### DIFF
--- a/CardDictionaries/PlayAbilities.php
+++ b/CardDictionaries/PlayAbilities.php
@@ -65,7 +65,7 @@ function AAZPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
       AddCurrentTurnEffect($cardID, $currentPlayer);
       $arsenal = &GetArsenal($currentPlayer);
       for ($i = 0; $i < count($arsenal); $i += ArsenalPieces()) {
-        if ($arsenal[$i + 1] == "DOWN") {
+        if ($arsenal[$i + 1] == "DOWN" && ArsenalHasFaceDownArrowCard($currentPlayer)) {
           AddDecisionQueue("YESNO", $currentPlayer, "if_you_want_to_turn_your_arsenal_face_up");
           AddDecisionQueue("NOPASS", $currentPlayer, "-");
           AddDecisionQueue("TURNARSENALFACEUP", $currentPlayer, $i, 1);

--- a/CardDictionaries/PlayAbilities.php
+++ b/CardDictionaries/PlayAbilities.php
@@ -65,7 +65,7 @@ function AAZPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
       AddCurrentTurnEffect($cardID, $currentPlayer);
       $arsenal = &GetArsenal($currentPlayer);
       for ($i = 0; $i < count($arsenal); $i += ArsenalPieces()) {
-        if ($arsenal[$i + 1] == "DOWN" && ArsenalHasFaceDownArrowCard($currentPlayer)) {
+        if (ArsenalHasFaceDownArrowCard($currentPlayer)) {
           AddDecisionQueue("YESNO", $currentPlayer, "if_you_want_to_turn_your_arsenal_face_up");
           AddDecisionQueue("NOPASS", $currentPlayer, "-");
           AddDecisionQueue("TURNARSENALFACEUP", $currentPlayer, $i, 1);

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -1209,7 +1209,7 @@ function IsPlayRestricted($cardID, &$restriction, $from = "", $index = -1, $play
       return $discard->NumCards() < 3;
     case "ROS008": return GetClassState($player, $CS_NumLightningPlayed) == 0;
     case "ASB004": return count($mySoul) == 0;
-    case "AAZ005": return !ArsenalHasFaceDownCard($player);
+    case "AAZ005": return !ArsenalHasFaceDownArrowCard($player);
     case "AAZ007": return !HasAimCounter();
     default: return false;
   }

--- a/CardGetters.php
+++ b/CardGetters.php
@@ -365,6 +365,15 @@ function ArsenalHasFaceUpArrowCard($player)
   return false;
 }
 
+function ArsenalHasFaceDownArrowCard($player)
+{
+  $arsenal = &GetArsenal($player);
+  for ($i = 0; $i < count($arsenal); $i += ArsenalPieces()) {
+    if (CardSubType($arsenal[$i]) == "Arrow" && $arsenal[$i + 1] == "DOWN") return true;
+  }
+  return false;
+}
+
 function ArsenalFull($player)
 {
   $arsenal = &GetArsenal($player);

--- a/CharacterAbilities.php
+++ b/CharacterAbilities.php
@@ -770,6 +770,7 @@ function EquipPayAdditionalCosts($cardIndex, $from)
     case "DYN001":
     case "OUT096":
     case "TCC050":
+    case "AAZ005":
       break; //Unlimited uses
     case "ELE224": //Spellbound Creepers - Bind counters
       ++$character[$cardIndex + 2];//Add a counter


### PR DESCRIPTION
Fixed following:

 - Hidden Agenda could only be used once per turn
 - Hidden agenda could flip any card in arsenal not only arrows
 - Line it up could flip any card in arsenal not only arrows