### PR TITLE
fixing decompose and adding blossoming decay

### DIFF
--- a/CardDictionaries/Keywords.php
+++ b/CardDictionaries/Keywords.php
@@ -13,7 +13,7 @@
       case "EVO087": case "EVO088": case "EVO089":
       case "EVO090": case "EVO091": case "EVO092":
       case "EVO093": case "EVO094": case "EVO095":
-      case "EVO096": case "EVO097": case "EVO098": 
+      case "EVO096": case "EVO097": case "EVO098":
       case "AIO026":
         return true;
       default: return false;
@@ -352,7 +352,7 @@
    * Decompose is a keyword added in ROS. This function is meant to support future instances of
    * decompose that may have different requirements in the number of earth banishes and action
    * banishes.
-   * 
+   *
    * The result of "NOPASS" should be used to add the bonus effects. SPECIFICCARD dq events can be added right after calling decompose to run if the decompose succeeded.
    */
   function Decompose($player, $earthBanishes, $actionBanishes) {
@@ -362,16 +362,16 @@
     $countInDiscard = SearchCount(
       SearchRemoveDuplicates(
         CombineSearches(
-          SearchDiscard($player, talent: "EARTH"), 
+          SearchDiscard($player, talent: "EARTH"),
           CombineSearches(
-            SearchDiscard($player, "A"), 
+            SearchDiscard($player, "A"),
             SearchDiscard($player
             , "AA"))
           )
         )
       );
-    
-    // Must have the minimum # of earth cards too. 
+
+    // Must have the minimum # of earth cards too.
     $earthCountInDiscard = SearchCount(SearchDiscard($player, talent: "EARTH"));
 
     // This is a MAY ability.
@@ -388,7 +388,7 @@
         AddDecisionQueue("MZBANISH", $player, "GY,-," . $player, 1);
         AddDecisionQueue("MZREMOVE", $player, "-", 1);
       }
-      
+
       // Action banishes.
       for($i = 0; $i < $actionBanishes; $i++) {
         AddDecisionQueue("GETCARDSFORDECOMPOSE", $player, "MYDISCARD:type=A&MYDISCARD:type=AA", 1); // Modified MULTIZONEINDICES so if there are no actions it can be sent to the next dq and it will revert gamestate. Can't use "PASS" because YESNO "PASS" result is already present.
@@ -398,6 +398,9 @@
         AddDecisionQueue("MZBANISH", $player, "GY,-," . $player, 1);
         AddDecisionQueue("MZREMOVE", $player, "-", 1);
       }
+      return true;
+    }
+    else {
+      return false;
     }
   }
-  

--- a/CardDictionaries/Rosetta/ROSShared.php
+++ b/CardDictionaries/Rosetta/ROSShared.php
@@ -89,6 +89,7 @@ function ROSCombatEffectActive($cardID, $attackID): bool
     "ROS064", "ROS065", "ROS066" => true,
     "ROS127", "ROS128", "ROS129" => ClassContains($attackID, "RUNEBLADE", $mainPlayer),
     "ROS248" => CardSubType($attackID) == "Sword", // this conditional should remove both the buff and 2x attack bonus go again.
+    "ROS049", "ROS050", "ROS051" => true, //blossoming decay
     default => false,
   };
 }
@@ -146,8 +147,10 @@ function ROSPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
       AddCurrentTurnEffect($cardID, $currentPlayer);
       return "";
     case "ROS031":
-      Decompose($currentPlayer, 2, 1);
-      AddDecisionQueue("SPECIFICCARD", $currentPlayer, "FELLINGOFTHECROWN", 1);
+      $decomposed = Decompose($currentPlayer, 2, 1);
+      if ($decomposed){
+        AddDecisionQueue("SPECIFICCARD", $currentPlayer, "FELLINGOFTHECROWN", 1);
+      }
       return "";
     case "ROS035":
       IncrementClassState($currentPlayer, $CS_DamagePrevention, 5);
@@ -155,22 +158,37 @@ function ROSPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
     case "ROS039":
     case "ROS040":
     case "ROS041":
-      Decompose($currentPlayer, 2, 1);
-      AddDecisionQueue("SPECIFICCARD", $currentPlayer, "SUMMERSFALL", 1);
+      $decomposed = Decompose($currentPlayer, 2, 1);
+      if ($decomposed) {
+        AddDecisionQueue("SPECIFICCARD", $currentPlayer, "SUMMERSFALL", 1);
+      }
       return "";
     case "ROS042":
     case "ROS043":
     case "ROS044":
-      Decompose($currentPlayer, 2, 1);
-      AddDecisionQueue("PASSPARAMETER", $currentPlayer, $cardID, 1);
-      AddDecisionQueue("SPECIFICCARD", $currentPlayer, "ROOTBOUNDCARAPACE", 1);
+      $decomposed = Decompose($currentPlayer, 2, 1);
+      if ($decomposed) {
+        AddDecisionQueue("PASSPARAMETER", $currentPlayer, $cardID, 1);
+        AddDecisionQueue("SPECIFICCARD", $currentPlayer, "ROOTBOUNDCARAPACE", 1);
+      }
+      return "";
+    case "ROS049":
+    case "ROS050":
+    case "ROS051":
+      $decomposed = Decompose($currentPlayer, 2, 1);
+      if ($decomposed) {
+        AddDecisionQueue("PASSPARAMETER", $currentPlayer, $cardID, 1);
+        AddDecisionQueue("SPECIFICCARD", $currentPlayer, "BLOSSOMINGDECAY", 1);
+      }
       return "";
     case "ROS052":
     case "ROS053":
     case "ROS054":
-      Decompose($currentPlayer, 2, 1);
-      AddDecisionQueue("PASSPARAMETER", $currentPlayer, $cardID, 1);
-      AddDecisionQueue("SPECIFICCARD", $currentPlayer, "CADAVEROUSTILLING", 1);
+      $decomposed = Decompose($currentPlayer, 2, 1);
+      if ($decomposed) {
+        AddDecisionQueue("PASSPARAMETER", $currentPlayer, $cardID, 1);
+        AddDecisionQueue("SPECIFICCARD", $currentPlayer, "CADAVEROUSTILLING", 1);
+      }
       return "";
     case "ROS055":
     case "ROS056":

--- a/DecisionQueue/DecisionQueueEffects.php
+++ b/DecisionQueue/DecisionQueueEffects.php
@@ -3,7 +3,7 @@
 function ModalAbilities($player, $card, $lastResult, $index=-1)
 {
   global $combatChain, $defPlayer, $CombatChain, $combatChainState, $CS_ModalAbilityChoosen, $dqVars;
-  SetClassState($player, $CS_ModalAbilityChoosen, $card."-".$lastResult[0]);  
+  SetClassState($player, $CS_ModalAbilityChoosen, $card."-".$lastResult[0]);
   AddDecisionQueue("CURRENTEFFECTAFTERPLAYORACTIVATEABILITY", $player, "<-");
   switch($card)
   {
@@ -33,7 +33,7 @@ function ModalAbilities($player, $card, $lastResult, $index=-1)
       for($i = 0; $i < count($lastResult); ++$i) {
         switch($lastResult[$i]) {
           case "Draw_a_card": {
-            Draw($player); 
+            Draw($player);
             break;
           }
           case "Buff_Power": {
@@ -41,7 +41,7 @@ function ModalAbilities($player, $card, $lastResult, $index=-1)
             break;
           }
           case "Go_again": {
-            GiveAttackGoAgain(); 
+            GiveAttackGoAgain();
             break;
           }
         }
@@ -730,6 +730,9 @@ function SpecificCardLogic($player, $card, $lastResult, $initiator)
     case "FELLINGOFTHECROWN":
       BottomDeck($player);
       BottomDeck($otherPlayer);
+      return $lastResult;
+    case "BLOSSOMINGDECAY":
+      GainHealth(1, $player);
       return $lastResult;
     case "ROOTBOUNDCARAPACE":
     case "CADAVEROUSTILLING":


### PR DESCRIPTION
Adding a return statement to decompose, it returns true if decomposing was possible, and false otherwise. If false the decision queues for the card abilities won't be added.