### PR TITLE
adding in the lifegain to the surge trigger

### DIFF
--- a/CardDictionaries/ArcaneRising/ARCWizard.php
+++ b/CardDictionaries/ArcaneRising/ARCWizard.php
@@ -906,7 +906,8 @@ function ProcessSurge($cardID, $player, $target)
     case "ROS173":
     case "ROS174":
     case "ROS175":
-      WriteLog("Surge Active, returning sigils to the deck");
+      WriteLog("Surge Active, gaining 1 life and returning sigils to the deck");
+      GainHealth(1, $player);
       $auras = &GetAuras($player);
       for ($i = count($auras) - AuraPieces(); $i >= 0; $i -= AuraPieces()) {
         $auraName = CardName($auras[$i]);


### PR DESCRIPTION
Completely missed that the card had a point of lifegain in it's surge. Should be fixed now.