### PR TITLE
fixing line it up

### DIFF
--- a/CardDictionaries/ArmoryDecks/AAZShared.php
+++ b/CardDictionaries/ArmoryDecks/AAZShared.php
@@ -71,7 +71,7 @@ function AAZPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
       AddCurrentTurnEffect($cardID, $currentPlayer);
       $arsenal = &GetArsenal($currentPlayer);
       for ($i = 0; $i < count($arsenal); $i += ArsenalPieces()) {
-        if (ArsenalHasFaceDownArrowCard($currentPlayer)) {
+        if (CardSubType($arsenal[$i]) == "Arrow" && $arsenal[$i + 1] == "DOWN"){
           AddDecisionQueue("YESNO", $currentPlayer, "if_you_want_to_turn_your_arsenal_face_up");
           AddDecisionQueue("NOPASS", $currentPlayer, "-");
           AddDecisionQueue("TURNARSENALFACEUP", $currentPlayer, $i, 1);


### PR DESCRIPTION
Line it up had a bug where if you have a face down arsenal card, it will let you put an aim counter on all arrows in  arsenal, not just the face down one. This PR should fix it.