### PR TITLE
Partial Arc Lightning

### DIFF
--- a/CardDictionaries/Rosetta/ROSShared.php
+++ b/CardDictionaries/Rosetta/ROSShared.php
@@ -89,6 +89,7 @@ function ROSCombatEffectActive($cardID, $attackID): bool
     "ROS110", "ROS111", "ROS112" => CardType($attackID) == "AA" && CardCost($attackID) <= 1,
     "ROS127", "ROS128", "ROS129", "ROS119" => ClassContains($attackID, "RUNEBLADE", $mainPlayer),
     "ROS118" => CardType($attackID) == "AA" && ClassContains($attackID, "RUNEBLADE", $mainPlayer),
+    "ROS010" => $from != "PLAY" && (TypeContains($attackID, "AA", $mainPlayer) || TypeContains($attackID, "A", $mainPlayer)), //Arc Lightning giving next action go again
     "ROS248" => CardSubType($attackID) == "Sword", // this conditional should remove both the buff and 2x attack bonus go again.
     "ROS049", "ROS050", "ROS051" => true, //blossoming decay
     default => false,

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -689,6 +689,7 @@ function HasGoAgain($cardID): bool|int
     case "TER017":
     case "TER019":
     case "TER024":
+    case "ROS010":
     case "ROS061":
     case "ROS062":
     case "ROS063":


### PR DESCRIPTION
Added code to (assumingly) give Arc Lightning go again, as well as the next action card they play have go again. Arcane damage not figured out yet.