### PR TITLE
Revert "When dealing arcane damage with meld card, the correct name of the side is shown"

### DIFF
--- a/CardDictionaries/ArcaneRising/ARCWizard.php
+++ b/CardDictionaries/ArcaneRising/ARCWizard.php
@@ -156,17 +156,9 @@ function ARCWizardHitEffect($cardID)
 //2: Any Target
 //3: Their Hero + Their Allies
 //4: My Hero only (For afflictions)
-function DealArcane($damage, $target = 0, $type = "PLAYCARD", $source = "NA", $fromQueue = false, $player = 0, $mayAbility = false, $limitDuplicates = false, $skipHitEffect = false, $resolvedTarget = "", $nbArcaneInstance = 1, $isPassable = 0, $meldSide = "-")
+function DealArcane($damage, $target = 0, $type = "PLAYCARD", $source = "NA", $fromQueue = false, $player = 0, $mayAbility = false, $limitDuplicates = false, $skipHitEffect = false, $resolvedTarget = "", $nbArcaneInstance = 1, $isPassable = 0)
 {
   global $currentPlayer, $CS_ArcaneTargetsSelected;
-  $meldCardName = "-";
-  if ($meldSide != "-") {
-    $meldNames = explode(" // ", CardName($source));
-    $meldCardName = match ($meldSide) {
-      "LEFT" => $meldNames[0],
-      "RIGHT" => $meldNames[1]
-    };
-  }
   if ($player == 0) $player = $currentPlayer;
   if ($damage > 0) {
     $damage += CurrentEffectArcaneModifier($source, $player) * $nbArcaneInstance;
@@ -183,16 +175,9 @@ function DealArcane($damage, $target = 0, $type = "PLAYCARD", $source = "NA", $f
         PrependDecisionQueue("PASSPARAMETER", $currentPlayer, $resolvedTarget);
       } else {
         PrependDecisionQueue("SETDQVAR", $currentPlayer, "0", 1);
-        if ($mayAbility) {
-          PrependDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
-        } else {
-          PrependDecisionQueue("CHOOSEMULTIZONE", $player, "<-", 1);
-        }
-        if ($meldCardName == "-") {
-          AddDecisionQueue("SETDQCONTEXT", $player, "Choose a target for <0>", ($isPassable ? 1 : 0));
-        } else {
-          AddDecisionQueue("SETDQCONTEXT", $player, "Choose a target for " . $meldCardName, ($isPassable ? 1 : 0));
-        }
+        if ($mayAbility) PrependDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
+        else PrependDecisionQueue("CHOOSEMULTIZONE", $player, "<-", 1);
+        PrependDecisionQueue("SETDQCONTEXT", $player, "Choose a target for <0>");
         PrependDecisionQueue("FINDINDICES", $player, "ARCANETARGET," . $target);
         PrependDecisionQueue("SETDQVAR", $currentPlayer, "0");
         PrependDecisionQueue("PASSPARAMETER", $currentPlayer, $source);
@@ -204,16 +189,9 @@ function DealArcane($damage, $target = 0, $type = "PLAYCARD", $source = "NA", $f
         AddDecisionQueue("PASSPARAMETER", $currentPlayer, $source, ($isPassable ? 1 : 0));
         AddDecisionQueue("SETDQVAR", $currentPlayer, "0", ($isPassable ? 1 : 0));
         AddDecisionQueue("FINDINDICES", $player, "ARCANETARGET," . $target, ($isPassable ? 1 : 0));
-        if ($meldCardName == "-") {
-          AddDecisionQueue("SETDQCONTEXT", $player, "Choose a target for <0>", ($isPassable ? 1 : 0));
-        } else {
-          AddDecisionQueue("SETDQCONTEXT", $player, "Choose a target for " . $meldCardName, ($isPassable ? 1 : 0));
-        }
-        if ($mayAbility) {
-          AddDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
-        } else {
-          AddDecisionQueue("CHOOSEMULTIZONE", $player, "<-", 1);
-        }
+        AddDecisionQueue("SETDQCONTEXT", $player, "Choose a target for <0>", ($isPassable ? 1 : 0));
+        if ($mayAbility) AddDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
+        else AddDecisionQueue("CHOOSEMULTIZONE", $player, "<-", 1);
         AddDecisionQueue("SETDQVAR", $currentPlayer, "0", 1);
       }
       AddDecisionQueue("DEALARCANE", $player, $damage . "-" . $source . "-" . $type, 1);
@@ -380,8 +358,8 @@ function PlayRequiresTarget($cardID)
     case "ROS190":
     case "ROS191":
       return 0;//Etchings of Arcana
-    case "ROS195":
-    case "ROS196":
+    case "ROS195": 
+    case "ROS196": 
     case "ROS197":
       return 0; //Open the Flood Gates
     case "ROS198":
@@ -985,14 +963,14 @@ function ProcessSurge($cardID, $player, $target)
         MZChooseAndDestroy($player, "THEIRARS");
       }
       break;
-    case "ROS167"://eternal inferno
-      BanishCardForPlayer("ROS167", $player, "MYDISCARD", "TT", "ROS167");
-      $discard = &GetDiscard($player);
-      for ($i = 0; $i < DiscardPieces(); $i++) {
-        array_pop($discard);
-      }
-      $banish = GetBanish($player);
-      break;
+      case "ROS167"://eternal inferno
+        BanishCardForPlayer("ROS167", $player, "MYDISCARD", "TT", "ROS167");
+        $discard = &GetDiscard($player);
+        for($i = 0; $i < DiscardPieces(); $i++){
+          array_pop($discard);
+        }
+        $banish = GetBanish($player);
+        break;
     case "ROS176":
     case "ROS177":
     case "ROS178":
@@ -1004,8 +982,8 @@ function ProcessSurge($cardID, $player, $target)
       WriteLog("Surge active, returning a sigil from graveyard to hand");
       MZMoveCard($player, "MYDISCARD:subtype=Aura;nameIncludes=Sigil", "MYHAND", may: true);
       break;
-    case "ROS195":
-    case "ROS196":
+    case "ROS195": 
+    case "ROS196": 
     case "ROS197":
       WriteLog("Surge active, drawing 2 cards");
       Draw($player);
@@ -1023,7 +1001,7 @@ function ProcessSurge($cardID, $player, $target)
       WriteLog("Surge active, returning to the bottom of the deck");
       AddBottomDeck($cardID, $player, "STACK"); //create a copy on the bottom
       $discard = &GetDiscard($player);
-      for ($i = 0; $i < DiscardPieces(); $i++) {
+      for($i = 0; $i < DiscardPieces(); $i++){
         array_pop($discard);
       }
       break;

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -3888,10 +3888,19 @@ function HasAttackLayer()
   return false;
 }
 
-function HasMeld($cardID): bool
-{
-  return match ($cardID) {
-    "ROS005", "ROS006", "ROS011", "ROS012", "ROS017", "ROS018", "ROS023", "ROS024", "ROS253" => true,
-    default => false
-  };
+function HasMeld($cardID){
+  switch ($cardID) {
+    case "ROS005":
+    case "ROS006":
+    case "ROS011":
+    case "ROS012":
+    case "ROS017":
+    case "ROS018":
+    case "ROS023":
+    case "ROS024":
+    case "ROS253":
+      return true;
+    default:
+      return false;
+  }  
 }

--- a/DecisionQueue/DecisionQueueEffects.php
+++ b/DecisionQueue/DecisionQueueEffects.php
@@ -792,7 +792,7 @@ function MeldCards($player, $cardID, $lastResult){
         ResolveGoAgain($cardID, $player, "MELD");
         break;
       case "Shock":
-        DealArcane(1, 2, "PLAYCARD", $cardID, false, $player, meldSide: "RIGHT");
+        DealArcane(1, 2, "PLAYCARD", $cardID, false, $player);
         break;
       case "Thistle Bloom":
         PlayAura("ARC112", $player, GetClassState($player, $CS_HealthGained));
@@ -827,7 +827,7 @@ function MeldCards($player, $cardID, $lastResult){
         AddDecisionQueue("NEGATE", $player, "<-", 1);
         break;
       case "Comet Storm":
-        DealArcane(5, 2, "PLAYCARD", $cardID, false, $player, meldSide: "LEFT");
+        DealArcane(5, 2, "PLAYCARD", $cardID, false, $player);
         break;
       case "Regrowth":
         ResolveGoAgain($cardID, $player, "MELD");

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -281,7 +281,7 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
         if ($parameter == "False") PutItemIntoPlayForPlayer($lastResult, $player, mainPhase: $parameter);
         else PutItemIntoPlayForPlayer($lastResult, $player, ($parameter != "-" ? $parameter : 0));
       } else if (DelimStringContains($subtype, "Aura")) {
-        PlayAura($lastResult, $player, effectController: $parameter);
+        PlayAura($lastResult, $player, effectController:$parameter);
         PlayAbility($lastResult, "-", 0);
       }
       return $lastResult;
@@ -829,7 +829,7 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
     case "WRITELOGCARDLINK":
       $params = explode("_", $parameter);
       Writelog(CardLink($params[0], $params[0]) . " was choosen");
-      return $lastResult;
+      return $lastResult;  
     case "WRITELOGLASTRESULT":
       WriteLog("<b>" . $lastResult . "<b> was selected.");
       return $lastResult;
@@ -913,7 +913,7 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
       if ($lastResult > $parameter) return "PASS";
       return $lastResult;
     case "REVERTGAMESTATEIFNULL":
-      if ($lastResult == "") {
+      if ($lastResult == ""){
         WriteLog(implode(" ", explode("_", $parameter)), highlight: true);
         RevertGamestate();
       }
@@ -1572,7 +1572,7 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
       return $lastResult;
     case "DECDQVARIFNOTPASS":
       if ($lastResult != "PASS") $dqVars[$parameter] = intval($dqVars[$parameter]) - 1;
-      return $lastResult;
+      return $lastResult;   
     case "DIVIDE":
       return floor($lastResult / $parameter);
     case "DQVARPASSIFSET":
@@ -1636,7 +1636,7 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
       $params = explode(",", $parameter);
       return ModalAbilities($player, $params[0], $lastResult, isset($params[1]) ? $params[1] : -1);
     case "MELD":
-      MeldCards($player, $parameter, $lastResult);
+      MeldCards($player, $parameter, $lastResult); 
       return $lastResult;
     case "SCOUR":
       WriteLog("Scour deals " . $parameter . " arcane damage");
@@ -2261,7 +2261,7 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
       $CombatChain->Remove(0);
       return $lastResult;
     case "TRUCE":
-      if (SearchCurrentTurnEffects("ROS219", $defPlayer, remove: true)) {
+      if (SearchCurrentTurnEffects("ROS219", $defPlayer, remove: true)){
         $theirAuras = &GetAuras($defPlayer);
         for ($i = count($theirAuras) - AuraPieces(); $i >= 0; $i -= AuraPieces()) {
           switch ($theirAuras[$i]) {

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -1059,7 +1059,7 @@ function ResolveChainLink()
     DamageTrigger($defPlayer, $damage, "COMBAT", $combatChain[0]); //Include prevention
     AddDecisionQueue("RESOLVECOMBATDAMAGE", $mainPlayer, "-");
   }
-
+  
   ProcessDecisionQueue();
 }
 
@@ -1130,9 +1130,9 @@ function FinalizeChainLink($chainClosed = false)
   UpdateGameState($currentPlayer);
   BuildMainPlayerGameState();
   if (DoesAttackHaveGoAgain() && !$chainClosed) {
-    if (SearchCurrentTurnEffects("ROS010", $currentPlayer)) {
+    if(SearchCurrentTurnEffects("ROS010", $currentPlayer)) {
       $count = CountCurrentTurnEffects("ROS010", $currentPlayer);
-      for ($i = 0; $i < $count; $i++) {
+      for ($i=0; $i < $count; $i++) { 
         AddLayer("TRIGGER", $currentPlayer, "ROS010");
       }
     }
@@ -1505,7 +1505,7 @@ function PlayCard($cardID, $from, $dynCostResolved = -1, $index = -1, $uniqueID 
     if ($dynCostResolved >= 0) {
       SetClassState($currentPlayer, $CS_DynCostResolved, $dynCostResolved);
       $baseCost = ($from == "PLAY" || $from == "EQUIP" ? AbilityCost($cardID) : (CardCost($cardID) + SelfCostModifier($cardID, $from)));
-      if (HasMeld($cardID) && GetClassState($currentPlayer, $CS_AdditionalCosts) == "Both") $baseCost += $baseCost;
+      if(HasMeld($cardID) && GetClassState($currentPlayer, $CS_AdditionalCosts) == "Both") $baseCost += $baseCost;
       if (!$playingCard) $resources[1] += $dynCostResolved;
       else {
         $isAlternativeCostPaid = IsAlternativeCostPaid($cardID, $from);
@@ -1586,13 +1586,13 @@ function PlayCard($cardID, $from, $dynCostResolved = -1, $index = -1, $uniqueID 
     $canPlayAsInstant = CanPlayAsInstant($cardID, $index, $from) || (DelimStringContains($cardType, "I") && $turn[0] != "M");
     SetClassState($currentPlayer, $CS_PlayedAsInstant, "0");
     IncrementClassState($currentPlayer, $CS_NumCardsPlayed);
-    if ($CombatChain->HasCurrentLink() && $CombatChain->AttackCard()->ID() == "ROS076" && DelimStringContains(CardType($cardID), "I") && $currentPlayer == $mainPlayer) {
-      if (SearchCurrentTurnEffects("ROS076", $mainPlayer, true)) {
-        AddDecisionQueue("YESNO", $mainPlayer, "if you want to return " . CardLink("ROS076", "ROS076") . " to your hand?");
+    if($CombatChain->HasCurrentLink() && $CombatChain->AttackCard()->ID() == "ROS076" && DelimStringContains(CardType($cardID), "I") && $currentPlayer == $mainPlayer) {
+      if(SearchCurrentTurnEffects("ROS076", $mainPlayer, true)) {
+        AddDecisionQueue("YESNO", $mainPlayer, "if you want to return ".CardLink("ROS076", "ROS076")." to your hand?");
         AddDecisionQueue("NOPASS", $mainPlayer, "-");
         AddDecisionQueue("GONEINAFLASH", $mainPlayer, "-", 1);
       }
-    }
+    } 
     if (IsStaticType($cardType, $from, $cardID)) {
       $playType = GetResolvedAbilityType($cardID, $from);
       $abilityType = $playType;
@@ -1604,7 +1604,7 @@ function PlayCard($cardID, $from, $dynCostResolved = -1, $index = -1, $uniqueID 
     } else {
       if (GetClassState($currentPlayer, $CS_NamesOfCardsPlayed) == "-") SetClassState($currentPlayer, $CS_NamesOfCardsPlayed, $cardID);
       else SetClassState($currentPlayer, $CS_NamesOfCardsPlayed, GetClassState($currentPlayer, $CS_NamesOfCardsPlayed) . "," . $cardID);
-      if (DelimStringContains($cardType, "A") || $cardType == "AA") {
+      if (DelimStringContains($cardType, "A") || $cardType == "AA"){
         if (GetClassState($currentPlayer, $CS_ActionsPlayed) == "-") SetClassState($currentPlayer, $CS_ActionsPlayed, $cardID);
         else SetClassState($currentPlayer, $CS_ActionsPlayed, GetClassState($currentPlayer, $CS_ActionsPlayed) . "," . $cardID);
       }
@@ -1664,7 +1664,7 @@ function PlayCard($cardID, $from, $dynCostResolved = -1, $index = -1, $uniqueID 
         MZChooseAndBounce($currentPlayer, "THEIRAURAS:minCost=0;maxCost=1&THEIRAURAS:type=T&MYAURAS:minCost=0;maxCost=1&MYAURAS:type=T", may: true, context: "Choose an aura to return to its controller's hand");
         $combatChainState[$CCS_NextInstantBouncesAura] = 0;
       }
-    }
+    } 
     PayAdditionalCosts($cardID, $from);
     ResetCardPlayed($cardID);
   }
@@ -1854,10 +1854,10 @@ function AddPrePitchDecisionQueue($cardID, $from, $index = -1)
       AddDecisionQueue("SETABILITYTYPE", $currentPlayer, $cardID);
     }
   }
-  if (HasMeld($cardID)) {
+  if(HasMeld($cardID)) {
     $names = explode(" // ", CardName($cardID));
-    $option = "Both," . $names[0] . "," . $names[1];
-    if (DelimStringContains(CardType($cardID), "A") && $turn[0] != "M" && !$combatChainState[$CCS_EclecticMag] && GetClassState($currentPlayer, $CS_NextWizardNAAInstant) == 0) {
+    $option = "Both,".$names[0].",".$names[1];
+    if(DelimStringContains(CardType($cardID), "A") && $turn[0] != "M" && !$combatChainState[$CCS_EclecticMag] && GetClassState($currentPlayer, $CS_NextWizardNAAInstant) == 0) {
       $option = $names[1];
     }
     AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose which halves to activate");


### PR DESCRIPTION
I would like that if we make this change we do 100% of it changes so there its consistent across the board.

A bit of feedback:
- Can it be added to the chat also?
- Can we keep the meld cards highlighted in the pop-ups?