### PR TITLE
Setting tarpit trap to not lose its effect on

### DIFF
--- a/CombatChain.php
+++ b/CombatChain.php
@@ -4,7 +4,7 @@ function ProcessHitEffect($cardID, $from = "-")
 {
   global $CombatChain, $layers, $mainPlayer;
   WriteLog("Processing hit effect for " . CardLink($cardID, $cardID));
-  if (CardType($CombatChain->AttackCard()->ID()) == "AA" && SearchCurrentTurnEffects("OUT108", $mainPlayer, count($layers) <= LayerPieces())) return true;
+  if (CardType($cardID) == "AA" && SearchCurrentTurnEffects("OUT108", $mainPlayer, count($layers) <= LayerPieces())) return true;
   $cardID = ShiyanaCharacter($cardID);
   $set = CardSet($cardID);
   $class = CardClass($cardID);


### PR DESCRIPTION
dagger throws

I definitely would like someone to check this fix. The original had some strange logic that I didn't fully understand, and the fix was relatively simple so I'm not sure if it may have some unforeseen consequence.