### PR TITLE
band-aid fix

### DIFF
--- a/CardLogic.php
+++ b/CardLogic.php
@@ -214,7 +214,8 @@ function AddLayer($cardID, $player, $parameter, $target = "-", $additionalCosts 
   array_unshift($layers, $parameter);
   array_unshift($layers, $player);
   array_unshift($layers, $cardID);
-  if ($cardID == "TRIGGER") {
+  // doesn't allow ordering of runechants, but prevents things from breaking
+  if ($cardID == "TRIGGER" && $parameter != "ARC112") {
     $orderableIndex = intval($dqState[8]);
     if ($orderableIndex == -1) $dqState[8] = 0;
     else $dqState[8] += LayerPieces();


### PR DESCRIPTION
Something about reordering runechants is adding two values to the end of the $layers array, which is always assumed to be a multiple of LayerPieces() (currently 7). I can't find where these values are getting added, but they are present in GetNextTurn3-4.php, and my guess is that somewhere else is reading bad data because of this which is causing a bizarre bug where blocking with cards requires the defender to pay for them (and disallows blocking with cards without a cost).

This is a band-aid fix that removes the functionality to reorder runechants, but dodges the above bugs.