### PR TITLE
Only modify if the event occurs

### DIFF
--- a/AuraAbilities.php
+++ b/AuraAbilities.php
@@ -14,7 +14,8 @@ function PlayAura($cardID, $player, $number = 1, $isToken = false, $rogueHeronSp
   $numMinusTokens = 0;
   $numMinusTokens = CountCurrentTurnEffects("HVY209", $player) + CountCurrentTurnEffects("HVY209", $otherPlayer);
 
-  $number += CharacterModifiesPlayAura($player, $isToken, $effectController);
+  // only modify the event if there is an event
+  if ($number > 0) $number += CharacterModifiesPlayAura($player, $isToken, $effectController);
 
   if ($numMinusTokens > 0 && $isToken && (TypeContains($EffectContext, "AA", $player) || TypeContains($EffectContext, "A", $player))) $number -= $numMinusTokens;
   if ($cardID == "ARC112") $number += CountCurrentTurnEffects("ARC081", $player);


### PR DESCRIPTION
I am noticing a minor bug in this code as on florian's opponent's turn, if he plays an effect that makes a single runechant and the opponent responds with ripple away, they should stop the whole event because they get to order the replacement effects. I'm not sure it's worth fixing until someone reports it though.