### PR TITLE
Pass who banished the card into check contracts

### DIFF
--- a/CardSetters.php
+++ b/CardSetters.php
@@ -73,7 +73,9 @@ function BanishCard(&$banish, &$classState, $cardID, $mod, $player = "", $from =
       CharacterBanishEffect($cardID, $player);
     } else DestroyCharacter($player, $charIndex, wasBanished: true);
   }
-  if ($banishedBy != "" && $player != $mainPlayer) CheckContracts($mainPlayer, $cardID);
+  if ($banishedBy != "" && $player != $mainPlayer){
+    CheckContracts($banishedBy, $cardID);
+  }
   if ($banishedBy == "DTD193" && TalentContains($cardID, "LIGHT", $player)) {
     GainHealth(1, $otherPlayer);
     return $rv;


### PR DESCRIPTION
I don't fully understand what this code was trying to do, but it was causing things like rootbound carapace and mask of recurring nightmares count towards contracts, which they should not.
It seems like an oversight, unless there's something I'm missing.