### PR TITLE
Wildfire and shock

### DIFF
--- a/CardDictionaries/ArcaneRising/ARCWizard.php
+++ b/CardDictionaries/ArcaneRising/ARCWizard.php
@@ -156,13 +156,13 @@ function ARCWizardHitEffect($cardID)
 //2: Any Target
 //3: Their Hero + Their Allies
 //4: My Hero only (For afflictions)
-function DealArcane($damage, $target = 0, $type = "PLAYCARD", $source = "NA", $fromQueue = false, $player = 0, $mayAbility = false, $limitDuplicates = false, $skipHitEffect = false, $resolvedTarget = "-", $nbArcaneInstance = 1, $isPassable = 0)
+function DealArcane($damage, $target = 0, $type = "PLAYCARD", $source = "NA", $fromQueue = false, $player = 0, $mayAbility = false, $limitDuplicates = false, $skipHitEffect = false, $resolvedTarget = "-", $nbArcaneInstance = 1, $isPassable = 0, $meldState = "-")
 {
   global $currentPlayer, $CS_ArcaneTargetsSelected;
   if ($player == 0) $player = $currentPlayer;
   $otherPlayer = $player == 1 ? 2 : 1;
   if ($damage > 0) {
-    $damage += CurrentEffectArcaneModifier($source, $player) * $nbArcaneInstance;
+    $damage += CurrentEffectArcaneModifier($source, $player, meldState: $meldState) * $nbArcaneInstance;
     if ($type != "PLAYCARD") WriteLog(CardLink($source, $source) . " is dealing " . $damage . " arcane damage.");
     if ($fromQueue) {
       if (!$limitDuplicates) {
@@ -427,7 +427,7 @@ function GetArcaneTargetIndices($player, $target): string
   return implode(",", $targets);
 }
 
-function CurrentEffectArcaneModifier($source, $player): int|string
+function CurrentEffectArcaneModifier($source, $player, $meldState = "-"): int|string
 {
   global $currentTurnEffects;
   $modifier = 0;
@@ -437,7 +437,8 @@ function CurrentEffectArcaneModifier($source, $player): int|string
     switch ($effectArr[0]) {
       case "EVR123":
         $cardType = CardType($source);
-        if (DelimStringContains($cardType, "A") || $cardType == "AA") $modifier += $effectArr[1];
+        if ((DelimStringContains($cardType, "A") || $cardType == "AA")
+          && (!HasMeld($source) || DelimStringContains($meldState, "A"))) $modifier += $effectArr[1];
         break;
       case "ROS017":
         if ($currentTurnEffects[$i + 1] != $player) break;

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -2932,7 +2932,7 @@ function ProcessMeld($player, $parameter)
       }
       break;
     case "ROS024":
-      DealArcane(5, 2, "PLAYCARD", $parameter, true, $player);
+      DealArcane(5, 2, "PLAYCARD", $parameter, true, $player, meldState: "A");
       break;
     case "ROS253":
       if (GetClassState($player, $CS_ArcaneDamageDealt) > 0) {

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -2932,7 +2932,9 @@ function ProcessMeld($player, $parameter)
       }
       break;
     case "ROS024":
-      DealArcane(5, 2, "PLAYCARD", $parameter, true, $player, meldState: "A");
+      $meldState = (GetClassState($player, $CS_AdditionalCosts) == "Both") ? "I,A" : "A";
+      WriteLog("meld state of action side " . $meldState);
+      DealArcane(5, 2, "PLAYCARD", $parameter, true, $player, meldState: $meldState);
       break;
     case "ROS253":
       if (GetClassState($player, $CS_ArcaneDamageDealt) > 0) {

--- a/DecisionQueue/DecisionQueueEffects.php
+++ b/DecisionQueue/DecisionQueueEffects.php
@@ -787,14 +787,16 @@ function MeldCards($player, $cardID, $lastResult){
   else $names[] = implode(" ", explode("_", $lastResult));
   if($lastResult == "Both") {
     AddLayer("MELD", $player, $cardID);
+    $meldState = CardType($cardID);
   }
+  else $meldState = "I";
   for ($i=count($names)-1; $i >= 0 ; --$i) { 
     switch ($names[$i]) {
       case "Life":
         GainHealth(1, $player);
         break;
       case "Shock": 
-        DealArcane(1, 2, "PLAYCARD", $cardID, false, $player);
+        DealArcane(1, 2, "PLAYCARD", $cardID, false, $player, meldState: $meldState);
         break;
       default:
         if($lastResult != "Both") {


### PR DESCRIPTION
I created a new variable $meldState that tracks the meld status of a melded card that deals arcane damage. That way wildfire, which only buffs the damage of action cards, will only buff shock if it is melded.