### PR TITLE
Fix Plume of Evergrowth

### DIFF
--- a/CardDictionaries/TalesOfAria/ELETalent.php
+++ b/CardDictionaries/TalesOfAria/ELETalent.php
@@ -41,7 +41,14 @@
         AddDecisionQueue("ADDCLASSSTATE", $currentPlayer, $CS_DamagePrevention . "-1", 1);
         return "";
       case "ELE116":
-        MZMoveCard($currentPlayer, "MYDISCARD:type=I;talent=EARTH&MYDISCARD:type=A;talent=EARTH&MYDISCARD:type=AA;talent=EARTH", "MYHAND");
+        $params = explode("-", $target);
+        $index = SearchdiscardForUniqueID($params[1], $currentPlayer);
+        if ($index != -1) {
+          AddDecisionQueue("PASSPARAMETER", $currentPlayer, "MYDISCARD-" . $index, 1);
+          AddDecisionQueue("MZADDZONE", $currentPlayer, "MYHAND", 1);
+        } else {
+          WriteLog(CardLink($cardID, $cardID) . " layer fails as there are no remaining targets for the targeted effect.");
+        }
         return "";
       case "ELE118":
         Draw($currentPlayer);

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -2389,6 +2389,13 @@ function PayAdditionalCosts($cardID, $from)
     case "ELE115":
       FaceDownArsenalBotDeck($currentPlayer);
       break;
+    case "ELE116":
+        AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "MYDISCARD:type=I;talent=EARTH&MYDISCARD:type=A;talent=EARTH&MYDISCARD:type=AA;talent=EARTH");
+        AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose Earth action card or Earth instant card");
+        AddDecisionQueue("CHOOSEMULTIZONE", $currentPlayer, "<-", 1);
+        AddDecisionQueue("SETLAYERTARGET", $currentPlayer, $cardID, 1);
+        AddDecisionQueue("SHOWSELECTEDTARGET", $currentPlayer, "-", 1);
+        break;
     case "ELE118":
       AddDecisionQueue("FINDINDICES", $currentPlayer, "ARSENAL");
       AddDecisionQueue("CHOOSEARSENAL", $currentPlayer, "<-", 1);


### PR DESCRIPTION
Instant - {r}{r}{r}, destroy Plume of Evergrowth: Return target Earth action card or Earth instant card from your graveyard to your hand.

the card was only targeting during resolution.

This solution still does not leave a mark on which card was the target of the spell, in case the adv wants to remove it from the graveyard.