### PR TITLE
Fix #978 Red in the Ledger on-hit effect

### DIFF
--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -1069,7 +1069,7 @@ function IsPlayable($cardID, $phase, $from, $index = -1, &$restriction = null, $
   }
   if (SearchCurrentTurnEffects("ARC044", $player) && !$isStaticType && $from != "ARS") return false;
   if (SearchCurrentTurnEffects("ARC043", $player)) {
-    if (!HasMeld($cardID) && (DelimStringContains($cardType, "A") || $cardType == "AA") && !str_contains($abilityTypes, "I") && GetClassState($player, $CS_NumActionsPlayed) >= 1) return false;
+    if (!HasMeld($cardID) && (DelimStringContains($cardType, "A") || $cardType == "AA") && !str_contains($abilityTypes, "I") && !GetClassState($player, $CS_NextNAAInstant) == 1 && GetClassState($player, $CS_NumActionsPlayed) >= 1) return false;
     if (str_contains($abilityTypes, "I") && ($from == "BANISH" || $from == "THEIRBANISH")) return false;
   }
   if (SearchCurrentTurnEffects("DYN154", $player) && !$isStaticType && DelimStringContains($cardType, "A") && GetClassState($player, $CS_NumNonAttackCards) >= 1) return false;

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -1069,7 +1069,7 @@ function IsPlayable($cardID, $phase, $from, $index = -1, &$restriction = null, $
   }
   if (SearchCurrentTurnEffects("ARC044", $player) && !$isStaticType && $from != "ARS") return false;
   if (SearchCurrentTurnEffects("ARC043", $player)) {
-    if (!HasMeld($cardID) && (DelimStringContains($cardType, "A") || $cardType == "AA") && !str_contains($abilityTypes, "I") && !GetClassState($player, $CS_NextNAAInstant) == 1 && GetClassState($player, $CS_NumActionsPlayed) >= 1) return false;
+    if (!HasMeld($cardID) && (DelimStringContains($cardType, "A") || $cardType == "AA") && !str_contains($abilityTypes, "I") && !CanPlayAsInstant($cardID, $index, $from) && !GetClassState($player, $CS_NextNAAInstant) == 1 && GetClassState($player, $CS_NumActionsPlayed) >= 1) return false;
     if (str_contains($abilityTypes, "I") && ($from == "BANISH" || $from == "THEIRBANISH")) return false;
   }
   if (SearchCurrentTurnEffects("DYN154", $player) && !$isStaticType && DelimStringContains($cardType, "A") && GetClassState($player, $CS_NumNonAttackCards) >= 1) return false;


### PR DESCRIPTION
These changes fix #978.

Adding an additional condition to the if statement to check that `!CanPlayAsInstant($cardID, $index, $from)` is true (i.e. the card attempting to be played cannot be played as an instant) fixes the on-hit effect when cards such as Succumb to Temptation have met the conditions to be played as an instant as shown in this screenshot:

![ritl-instant-bug-fixed](https://github.com/user-attachments/assets/6ccea24e-8dc8-4482-aed3-bc8779c1c192)

How I tested:

Built the project locally and added three lines to StarEffects.php to setup the conditions necessary to reproduce the bug around instant cards:

```
AddArsenal("ROS119", 1, "DECK", "DOWN");
PlayAura("ARC112", 1);
AddCurrentTurnEffect("ARC043", 1);
```

This allowed me to start turn 0 with Succumb to Temptation in arsenal, a Runechant in play and Red In the Ledger's on-hit effect active. 

Then loaded a single-player game up with my Viserai deck that contains Succumb, attacked with an attack action and confirmed that I was still able to play Succumb to Temptation at instant speed which was not possible before adding the additional check for `!CanPlayAsInstant($cardID, $index, $from)`.

The second thing I added was a check for `!GetClassState($player, $CS_NextNAAInstant) == 1` (i.e. the player does not currently have the ability to play their next non-attack action at instant speed) to the same if statement for ARC043 in `IsPlayable()`. This ensures that when card effects such as Spellbound Creepers are active, non-attack actions are able to be played at instant speed regardless of whether or not Red in the Ledger's on-hit effect is active as can be seen in this screenshot with Runic Reckoning:

![ritl-creepers-fixed](https://github.com/user-attachments/assets/861c3ab4-9232-4c90-a4e8-256719d5f0e9)


How I tested:

Update ELERuneblade.php to force the Red in the Ledge on hit effect when Spellbound Creepers are activated by adding

`AddCurrentTurnEffect("ARC043", $currentPlayer);`

To line 49 after the case statement for "ELE224" (Creepers card ID):
https://github.com/Talishar/Talishar/blob/03c94e7d9d837191215392e1a2bcafefb18ca615/CardDictionaries/TalesOfAria/ELERuneblade.php#L48

Start new game vs dummy as Viserai with Spellbound Creepers equipped

Play an attack action and activate Spellbound Creepers effect

Confirm that Red in the Ledger's on hit effect is active

Confirmed that before the change you cannot play a non-attack action at instant speed, but after the change you can play a non-attack action at instant speed when Spellbound Creeper's effect is active.

Please let me know if you would like any changes or have any questions.

Thank you.

