### PR TITLE
Fixing Jarl's play ability

### DIFF
--- a/CharacterAbilities.php
+++ b/CharacterAbilities.php
@@ -1337,7 +1337,7 @@ function MainCharacterPlayCardAbilities($cardID, $from)
         }
         break;
       case "AJV001":
-        if (TalentContains($cardID, "ICE", $currentPlayer)) {
+        if (TalentContains($cardID, "ICE", $currentPlayer) && !IsStaticType(CardType($cardID), $from, $cardID)) {
           AddLayer("TRIGGER", $currentPlayer, $characterID);
         }
         break;


### PR DESCRIPTION
Added StaticType check to fix Jarl's play ability so it doesn't trigger when an Ice card is activated but not played (i.e. Coronet Peak)