### PR TITLE
ball lighting to check card type

### DIFF
--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -604,7 +604,7 @@ function CurrentEffectDamageModifiers($player, $source, $type)
       case "ELE186":
       case "ELE187":
       case "ELE188":
-        if (TalentContainsAny($source, "LIGHTNING,ELEMENTAL", $player)) ++$modifier;
+        if (TalentContainsAny($source, "LIGHTNING,ELEMENTAL", $player) && (TypeContains($source, "A") || TypeContains($source, "AA"))) ++$modifier;
         break;
       default:
         break;


### PR DESCRIPTION
This fixes a bug where star fall was being buffed by ball lighting, but in testing I discovered another bug that may require a deeper investigation.
For whatever reason ball lightning is buffing the arcane damage from arc lightning twice. This bug is present both before and after my fix in this PR.