### PR TITLE
Adding "location" to aura removal, modifying the logic for equipped a…

### DIFF
--- a/CardLogic.php
+++ b/CardLogic.php
@@ -1618,12 +1618,8 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target = "-", $addition
       DestroyAuraUniqueID($player, $uniqueID);
       break;
       case "ELE111":
-        DestroyAuraUniqueID($player, $uniqueID);
-        if ($additionalCosts == "EQUIP") {
-          $index = SearchCharacterForUniqueID($uniqueID, $player);
-          RemoveCharacter($player, $index);
-        }
-        else DestroyAuraUniqueID($player, $uniqueID);
+        $location = $additionalCosts == "EQUIP" ? "EQUIP" : "AURAS";
+        DestroyAuraUniqueID($player, $uniqueID, $location);
         break;
     case "ELE174":
       $index = FindCharacterIndex($player, $parameter);


### PR DESCRIPTION
…uras

This should allow for merciful retribution to trigger on equipped frostbites breaking.
I had to dig pretty deep into some of the aura removal functions, and I'm fairly confident I'm not affecting anything other than equipped frostbites, but this is a pretty large change so if anyone has time to look over it that would be appreciated. I did test it with regular frostbites and their functionality appears to be intact.
The main updates were adding a $location variable that currently supports either "AURAS" or "EQUIP" as it's two values. I added two functions &GetAurasLocation (basically just a wrapper for either &GetAuras or &GetPlayerCharacter depending on $location) and AuraLocationConstants (effectively a lookup table for different constant values depending on $location).