### PR TITLE
making CMH not count twice when blocking

### DIFF
--- a/AuraAbilities.php
+++ b/AuraAbilities.php
@@ -1220,7 +1220,7 @@ function AuraHitEffects($attackID)
   }
 }
 
-function AuraAttackModifiers($index, &$attackModifiers)
+function AuraAttackModifiers($index, &$attackModifiers, $onBlock=false)
 {
   global $CombatChain, $combatChainState, $CCS_AttackPlayedFrom;
   global $CID_Frailty;
@@ -1228,24 +1228,26 @@ function AuraAttackModifiers($index, &$attackModifiers)
   $modifier = 0;
   $player = $chainCard->PlayerID();
   $myAuras = &GetAuras($player);
-  for ($i = 0; $i < count($myAuras); $i += AuraPieces()) {
-    switch ($myAuras[$i]) {
-      case "ELE117":
-        if (CardType($chainCard->ID()) == "AA") {
-          $modifier += 3;
-          array_push($attackModifiers, $myAuras[$i]);
-          array_push($attackModifiers, 3);
-        }
-        break;
-      case $CID_Frailty:
-        if ($index == 0 && (IsWeaponAttack() || $combatChainState[$CCS_AttackPlayedFrom] == "ARS")) {
-          $modifier -= 1;
-          array_push($attackModifiers, $myAuras[$i]);
-          array_push($attackModifiers, -1);
-        }
-        break;
-      default:
-        break;
+  if (!$onBlock) {//This codeblock was counting CMH twice on block
+    for ($i = 0; $i < count($myAuras); $i += AuraPieces()) {
+      switch ($myAuras[$i]) {
+        case "ELE117":
+          if (CardType($chainCard->ID()) == "AA") {
+            $modifier += 3;
+            array_push($attackModifiers, $myAuras[$i]);
+            array_push($attackModifiers, 3);
+          }
+          break;
+        case $CID_Frailty:
+          if ($index == 0 && (IsWeaponAttack() || $combatChainState[$CCS_AttackPlayedFrom] == "ARS")) {
+            $modifier -= 1;
+            array_push($attackModifiers, $myAuras[$i]);
+            array_push($attackModifiers, -1);
+          }
+          break;
+        default:
+          break;
+      }
     }
   }
   $theirAuras = &GetAuras($player == 1 ? 2 : 1);

--- a/CardDictionaries/Monarch/MONIllusionist.php
+++ b/CardDictionaries/Monarch/MONIllusionist.php
@@ -151,7 +151,7 @@
     if(ClassContains($card->ID(), "ILLUSIONIST", $defPlayer)) return false;
     if(PowerCantBeModified($card->ID())) return AttackValue($card->ID()) >= 6;
     $attackValue = ModifiedAttackValue($card->ID(), $defPlayer, "CC", source:$card->ID());
-    $attackValue += AuraAttackModifiers($index, $attackModifiers);
+    $attackValue += AuraAttackModifiers($index, $attackModifiers, onBlock: true);
     $attackValue += $card->AttackValue();//Combat chain attack modifier
     return $attackValue >= 6;
   }


### PR DESCRIPTION
It turns out AuraAttackModifiers was used for both CMH and parable of humility, and CMH was already covered by "$attackValue += $card->AttackValue();//Combat chain attack modifier"
So I added a binary check to see whether you're blocking or not, and if blocking it will only check for parable.