### PR TITLE
Make Earthlore bounty and stacked in your favor work

### DIFF
--- a/AuraAbilities.php
+++ b/AuraAbilities.php
@@ -565,9 +565,10 @@ function AuraStartTurnAbilities()
     case "HVY068":
     case "HVY069":
     case "HVY070":
+      $effectSource = $auras[$i];
       WriteLog("Resolving " . CardLink($auras[$i], $auras[$i]) . " ability");
       DestroyAuraUniqueID($mainPlayer, $auras[$i + 6]);
-      Draw($mainPlayer);
+      Draw($mainPlayer, effectSource: $effectSource);
       MZMoveCard($mainPlayer, "MYHAND", "MYTOPDECK", silent: true);
       break;
     case "HVY083":

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -2794,7 +2794,7 @@ function UnityEffect($cardID)
   }
 }
 
-function Draw($player, $mainPhase = true, $fromCardEffect = true)
+function Draw($player, $mainPhase = true, $fromCardEffect = true, $effectSource = "-")
 {
   global $EffectContext, $mainPlayer, $CS_NumCardsDrawn;
   $otherPlayer = ($player == 1 ? 2 : 1);
@@ -2824,8 +2824,9 @@ function Draw($player, $mainPhase = true, $fromCardEffect = true)
   }
   if ($mainPhase && (SearchCharacterActive($otherPlayer, "EVR019") || (SearchCurrentTurnEffects("EVR019-SHIYANA", $otherPlayer) && SearchCharacterActive($otherPlayer, "CRU097")))) PlayAura("WTR075", $otherPlayer);
   if (SearchCharacterActive($player, "EVR020")) {
-    if ($EffectContext != "-") {
-      $cardType = CardType($EffectContext);
+    $context = $effectSource != "-" ? $effectSource : $EffectContext;
+    if ($context != "-") {
+      $cardType = CardType($context);
       if (DelimStringContains($cardType, "A") || $cardType == "AA") PlayAura("WTR075", $player);
     }
   }


### PR DESCRIPTION
$EffectContext was getting overwritten asynchronously if there were other auras triggering at the start of turn/action phase, so I added an optional argument to Draw that allows you to specify which effect is causing the draw in cases where $EffectContext is unreliable.