### PR TITLE
passing additional cost as an argument

### DIFF
--- a/CardLogic.php
+++ b/CardLogic.php
@@ -3054,6 +3054,7 @@ function IsHeroActive($player)
 
 function ProcessMeld($player, $parameter, $additionalCosts="")
 {
+  // handles running the left side of meld cards
   global $CS_ArcaneDamageDealt, $CS_HealthGained, $CS_AdditionalCosts;
   switch ($parameter) {
     case "ROS005":
@@ -3105,6 +3106,6 @@ function ProcessMeld($player, $parameter, $additionalCosts="")
     default:
       break;
   }
-  ResolveGoAgain($parameter, $player, "MELD");
+  ResolveGoAgain($parameter, $player, "MELD", additionalCosts: $additionalCosts);
   if(GetClassState($player, $CS_AdditionalCosts) == "Both" || $additionalCosts == "MELD") ResolveGoesWhere("GY", $parameter, $player, "MELD"); //Only needs to be handled specifically here when playing both side of a Meld card
 }

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -2089,7 +2089,7 @@ function EndTurnPitchHandling($player)
   }
 }
 
-function ResolveGoAgain($cardID, $player, $from="")
+function ResolveGoAgain($cardID, $player, $from="", $additionalCosts="-")
 {
   global $CS_NextNAACardGoAgain, $actionPoints, $mainPlayer, $CS_ActionsPlayed, $CS_AdditionalCosts;
   $actionsPlayed = explode(",", GetClassState($player, $CS_ActionsPlayed));
@@ -2112,13 +2112,16 @@ function ResolveGoAgain($cardID, $player, $from="")
     if (DelimStringContains($cardType, "I") && !HasMeld($cardID)){
       $hasGoAgain = CurrentEffectGrantsInstantGoAgain($cardID, $from) || $hasGoAgain;
     }
-    elseif (DelimStringContains($cardType, "I") && $from != "MELD" && IsMeldInstantName(GetClassState($player, $CS_AdditionalCosts))){
+    elseif (DelimStringContains($cardType, "I") && $from != "MELD" && IsMeldInstantName($additionalCosts)){
+      // handles case of only right side
       $hasGoAgain = CurrentEffectGrantsInstantGoAgain($cardID, $from) || $hasGoAgain;
     }
-    elseif ($from == "MELD" && GetClassState($player, $CS_AdditionalCosts) == "Both"){
+    elseif ($from == "MELD" && $additionalCosts == "MELD"){
+      // handles case of left side resolving after melding
       $hasGoAgain = CurrentEffectGrantsInstantGoAgain($cardID, $from) || $hasGoAgain || HasGoAgain($cardID);
     }
     elseif ($from == "MELD"){
+      // handles case of only left side
       $hasGoAgain = $hasGoAgain || HasGoAgain($cardID);
     }
   }

--- a/DecisionQueue/DecisionQueueEffects.php
+++ b/DecisionQueue/DecisionQueueEffects.php
@@ -805,7 +805,7 @@ function MeldCards($player, $cardID, $lastResult){
         break;
       default:
         if($lastResult != "Both") {
-          ProcessMeld($player, $cardID);
+          ProcessMeld($player, $cardID, additionalCosts:$lastResult);
         }
       break;
     }

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -2952,7 +2952,7 @@ function PlayCardEffect($cardID, $from, $resourcesPaid, $target = "-", $addition
     {
       if ($from != "EQUIP" && $from != "PLAY") WriteLog("Resolving play ability of " . CardLink($cardID, $cardID) . ($playText != "" ? ": " : ".") . $playText);
       else if ($from == "EQUIP" || $from == "PLAY") WriteLog("Resolving activated ability of " . CardLink($cardID, $cardID) . ($playText != "" ? ": " : ".") . $playText);
-      if (!$openedChain) ResolveGoAgain($cardID, $currentPlayer, $from);
+      if (!$openedChain) ResolveGoAgain($cardID, $currentPlayer, $from, additionalCosts: $additionalCosts);
     }
     CopyCurrentTurnEffectsFromAfterResolveEffects();
     CacheCombatResult();


### PR DESCRIPTION
Before meld was using the character state to grab additional costs, but if you responded to the meld card that additional cost in the character state was getting overwritten. I'm now passing it as an argument so it can't be overwritten.