### PR TITLE
Fixing how arcane buffs interact with comet storm

### DIFF
--- a/CardDictionaries/Rosetta/ROSShared.php
+++ b/CardDictionaries/Rosetta/ROSShared.php
@@ -629,3 +629,11 @@ function HasAuraWithSigilInName($player)
   }
   return false;
 }
+
+function IsDoubleArcane($cardID): bool //checks for cards that can shock, but not use up arcane buffs on the shock
+{
+  return match ($cardID) {
+    "ROS024" => true,
+    default => false,
+  };
+}

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -3106,7 +3106,6 @@ function ProcessMeld($player, $parameter, $additionalCosts="")
       break;
     case "ROS024":
       $meldState = (GetClassState($player, $CS_AdditionalCosts) == "Both") ? "I,A" : "A";
-      WriteLog("meld state of action side " . $meldState);
       DealArcane(5, 2, "PLAYCARD", $parameter, player:$player, meldState: $meldState);
       break;
     case "ROS253":

--- a/CardSetters.php
+++ b/CardSetters.php
@@ -526,7 +526,7 @@ function ClearNextCardArcaneBuffs($player, $playedCard = "", $from = "")
   }
 }
 
-function ConsumeArcaneBonus($player)
+function ConsumeArcaneBonus($player, $noRemove = false)
 {
   global $currentTurnEffects, $CS_ResolvingLayerUniqueID;
   $uniqueID = GetClassState($player, $CS_ResolvingLayerUniqueID);
@@ -537,7 +537,7 @@ function ConsumeArcaneBonus($player)
       $bonus = EffectArcaneBonus($currentTurnEffects[$i]);
       if ($bonus > 0) {
         $totalBonus += $bonus;
-        $remove = 1;
+        if (!$noRemove) $remove = 1;
       }
     }
     if ($remove == 1) RemoveCurrentTurnEffect($i);

--- a/DecisionQueue/DecisionQueueEffects.php
+++ b/DecisionQueue/DecisionQueueEffects.php
@@ -800,8 +800,9 @@ function MeldCards($player, $cardID, $lastResult){
       case "Life":
         GainHealth(1, $player);
         break;
-      case "Shock": 
-        DealArcane(1, 2, "PLAYCARD", $cardID, false, $player, meldState: $meldState);
+      case "Shock":
+        $type = count($names) > 1 && IsDoubleArcane($cardID) ? "ARCANESHOCK" : "PLAYCARD";
+        DealArcane(1, 2, $type, $cardID, false, $player, meldState: $meldState);
         break;
       default:
         if($lastResult != "Both") {

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -1177,6 +1177,11 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
         if (DelimStringContains($sourceType, "A") || $sourceType == "AA") $damage += CountCurrentTurnEffects("ELE065", $player);
         WriteLog(CardLink($source, $source) . " is dealing " . $damage . " arcane damage");
       }
+      if ($type == "ARCANESHOCK") {
+        $damage += ConsumeArcaneBonus($player, noRemove: true);
+        if (DelimStringContains($sourceType, "A") || $sourceType == "AA") $damage += CountCurrentTurnEffects("ELE065", $player);
+        WriteLog(CardLink($source, $source) . " is dealing " . $damage . " arcane damage");
+      }
       if ($target[0] == "THEIRALLY" || $target[0] == "MYALLY") {
         $allies = &GetAllies($targetPlayer);
         if ($allies[$target[1] + 6] > 0) {


### PR DESCRIPTION
Tested on this bug: "439383 - Comet Storm // Shock, only shock was buffed by Aether Flare. Both sides should have the buff"
Should also fix the interaction with crucible of aetherweave

(the update to CardLogic.php was just removing a debug line I accidentally left in there)