### PR TITLE
should remove retrace's current turn effect after use

### DIFF
--- a/CardDictionaries/Hunted/HNTShared.php
+++ b/CardDictionaries/Hunted/HNTShared.php
@@ -40,6 +40,8 @@ function HNTEffectAttackModifier($cardID): int
 function HNTCombatEffectActive($cardID, $attackID): bool
 {
   global $mainPlayer;
+  $dashArr = explode("-", $cardID);
+  $cardID = $dashArr[0];
   return match ($cardID) {
     "HNT071" => TalentContains($cardID, "DRACONIC", $mainPlayer),
     "HNT116" => true,


### PR DESCRIPTION
retrace wasn't properly counted as "CombatEffectActive" so it wasn't getting cleaned up properly