### PR TITLE
refactored fealty, should no longer work with dragons

### DIFF
--- a/CardDictionaries/Hunted/HNTShared.php
+++ b/CardDictionaries/Hunted/HNTShared.php
@@ -43,7 +43,7 @@ function HNTCombatEffectActive($cardID, $attackID): bool
   return match ($cardID) {
     "HNT071" => TalentContains($cardID, "DRACONIC", $mainPlayer),
     "HNT116" => true,
-    "HNT167" => true,
+    "HNT167" => DelimStringContains(CardType($attackID), "AA"),
     "HNT249" => true,
     default => false,
   };

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -1666,12 +1666,6 @@ function PlayCard($cardID, $from, $dynCostResolved = -1, $index = -1, $uniqueID 
     if (TalentContains($cardID, "LIGHTNING", $currentPlayer) && $from != "EQUIP" && $from != "PLAY" && GetResolvedAbilityType($cardID, $from) != "I") {
       IncrementClassState($currentPlayer, $CS_NumLightningPlayed);
     }
-    if (TypeContains($cardID, "W")) { // We'll need to add cases for Allies and Emperor Attacking
-      $index = SearchCurrentTurnEffectsForIndex("HNT167", $currentPlayer);
-      if ($index != -1) {
-        ++$currentTurnEffects[$index + 3];
-      }
-    }
     if (TalentContains($cardID, "DRACONIC", $currentPlayer) && $from != "EQUIP" && $from != "PLAY" && GetResolvedAbilityType($cardID, $from) != "I") {
       IncrementClassState($currentPlayer, $CS_NumDraconicPlayed);
       if (!TypeContains($cardID, "AA")) SearchCurrentTurnEffects("HNT167", $currentPlayer, remove:true);


### PR DESCRIPTION
I found a more elegant way to implement fealty's effect that doesn't need a hacky fix for weapons and dragon attacks
It will still not function correctly with emperor's ability, that one may need to be hard-coded in as an exception.