### PR TITLE
Graven call tracks by uniqueID to see where to put the counter

### DIFF
--- a/CardDictionaries/PlayAbilities.php
+++ b/CardDictionaries/PlayAbilities.php
@@ -374,12 +374,15 @@ function HVYPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
     case "HVY245":
       if ($from == "GY") {
         $character = &GetPlayerCharacter($currentPlayer);
-        EquipWeapon($currentPlayer, "HVY245");
-        $index = FindCharacterIndex($currentPlayer, "HVY245");
-        if ($character[$index + 3] == 0) {
-          ++$character[$index + 3];
-        } else {
-          ++$character[$index + 15];
+        $uniqueID = EquipWeapon($currentPlayer, "HVY245");
+        for ($i = 0; $i < count($character); $i += CharacterPieces()) {
+          if ($character[$i + 11] == $uniqueID) {
+            if ($character[$i + 3] == 0) {
+              ++$character[$i + 3];
+            } else {
+              ++$character[$i + 15];
+            }
+          }
         }
       }
       return "";

--- a/CharacterAbilities.php
+++ b/CharacterAbilities.php
@@ -794,6 +794,7 @@ function EquipWeapon($player, $card)
   $lastWeapon = 0;
   $replaced = 0;
   $numHands = 0;
+  $uniqueID = GetUniqueId($card, $player);
   //Replace the first destroyed weapon; if none you can't re-equip
   for ($i = CharacterPieces(); $i < count($char) && !$replaced; $i += CharacterPieces()) {
     if (TypeContains($char[$i], "W", $player)) {
@@ -810,7 +811,7 @@ function EquipWeapon($player, $card)
         $char[$i + 8] = 0;
         $char[$i + 9] = CharacterDefaultActiveState($card);
         $char[$i + 10] = "-";
-        $char[$i + 11] = GetUniqueId($card, $player);
+        $char[$i + 11] = $uniqueID;
         $char[$i + 12] = HasCloaked($card, $player);
         $char[$i + 13] = 0;
         $replaced = 1;
@@ -835,6 +836,7 @@ function EquipWeapon($player, $card)
     array_splice($char, $insertIndex + 12, 0, HasCloaked($card, $player));
     array_splice($char, $insertIndex + 13, 0, 0);
   }
+  return $uniqueID;
 }
 
 function ShiyanaCharacter($cardID, $player = "")


### PR DESCRIPTION
fixing a bug where if you have two graven calls it will always put the counter on the first one