### PR TITLE
Added Chain Reaction code, added uniqueID tracking to CanPlayAsInstant check.

### DIFF
--- a/CardLogic.php
+++ b/CardLogic.php
@@ -67,7 +67,7 @@ function AddCurrentTurnEffect($cardID, $player, $from = "", $uniqueID = -1)
 {
   global $currentTurnEffects, $combatChain;
   $card = explode("-", $cardID)[0];
-  if (CardType($card) == "A" && !CanPlayAsInstant($cardID, -1, $from) && count($combatChain) > 0 && IsCombatEffectActive($cardID) && !IsCombatEffectPersistent($cardID) && $from != "PLAY") {
+  if (CardType($card) == "A" && !CanPlayAsInstant($cardID, -1, $from, $uniqueID) && count($combatChain) > 0 && IsCombatEffectActive($cardID) && !IsCombatEffectPersistent($cardID) && $from != "PLAY") {
     AddCurrentTurnEffectFromCombat($cardID, $player, $uniqueID);
     return;
   }
@@ -2672,6 +2672,22 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target = "-", $addition
     case "HNT246":
       DiscardRandom();
       break;
+    case "HNT253":
+      $arsenal = &GetArsenal($player);
+      for ($i = 0; $i < count($arsenal); $i += ArsenalPieces()) {
+        $arsenalCardID = $arsenal[$i];
+        $arsenalCardType = CardType($arsenalCardID);
+        if (DelimStringContains($cardType, "A") && $arsenal[$i + 1] == "DOWN"){
+          AddDecisionQueue("YESNO", $player, "if_you_want_to_turn_your_arsenal_face_up");
+          AddDecisionQueue("NOPASS", $player, "-");
+          AddDecisionQueue("TURNARSENALFACEUP", $player, $i, 1);
+          $arsenalCardUniqueID = $arsenal[$i + 5];
+          AddCurrentTurnEffect($parameter, $player, "ARS", $parameter . "-" . $arsenalCardUniqueID);
+          WriteLog("Trap triggered and grants instant speed to the flipped arsenal card until end of turn.");
+        }
+      }
+      TrapTriggered($parameter);
+    break;
     case "HNT256":
       GainHealth(1, $player);
       break;

--- a/CombatChain.php
+++ b/CombatChain.php
@@ -653,6 +653,9 @@ function OnDefenseReactionResolveEffects($from, $cardID)
     case "OUT173":
       if (!IsAllyAttacking() && HasIncreasedAttack()) AddLayer("TRIGGER", $defPlayer, $cardID);
       break;
+    case "HNT253":
+      if (DoesAttackHaveGoAgain()) AddLayer("TRIGGER", $defPlayer, $cardID);
+      break;
   }
   if ($blockedFromHand > 0 && SearchCharacterActive($mainPlayer, "ELE174", true) && (TalentContains($combatChain[0], "LIGHTNING", $mainPlayer) || TalentContains($combatChain[0], "ELEMENTAL", $mainPlayer))) {
     AddLayer("TRIGGER", $mainPlayer, "ELE174");

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -1256,7 +1256,7 @@ function GetBanishModifier($index)
   return "";
 }
 
-function CanPlayAsInstant($cardID, $index = -1, $from = "")
+function CanPlayAsInstant($cardID, $index = -1, $from = "", $uniqueID = "")
 {
   global $currentPlayer, $CS_NextWizardNAAInstant, $CS_NextNAAInstant, $CS_CharacterIndex, $CS_ArcaneDamageTaken, $CS_NumWizardNonAttack;
   global $mainPlayer, $CS_PlayedAsInstant, $CS_HealthLost, $CS_NumAddedToSoul;
@@ -1274,6 +1274,9 @@ function CanPlayAsInstant($cardID, $index = -1, $from = "")
   if ($cardType == "C" || $cardType == "E" || $cardType == "W") {
     if ($index == -1) $index = GetClassState($currentPlayer, $CS_CharacterIndex);
     if (SearchCharacterEffects($currentPlayer, $index, "INSTANT")) return true;
+  }
+  if ($from == "ARS" && DelimStringContains($cardType, "A") && $uniqueID != "") {
+    if (SearchCurrentTurnEffectsForUniqueID("HNT253-" . $uniqueID)) return true; // Chain Reaction granted instant speed
   }
   if ($from == "BANISH") {
     $banish = GetBanish($currentPlayer);

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -1591,7 +1591,7 @@ function PlayCard($cardID, $from, $dynCostResolved = -1, $index = -1, $uniqueID 
       }
       else ClearNextCardArcaneBuffs($currentPlayer, $cardID, $from);
     } 
-    $canPlayAsInstant = CanPlayAsInstant($cardID, $index, $from) || (DelimStringContains($cardType, "I") && $turn[0] != "M");
+    $canPlayAsInstant = CanPlayAsInstant($cardID, $index, $from, $uniqueID) || (DelimStringContains($cardType, "I") && $turn[0] != "M");
     SetClassState($currentPlayer, $CS_PlayedAsInstant, "0");
     IncrementClassState($currentPlayer, $CS_NumCardsPlayed);
     if($CombatChain->HasCurrentLink() && $CombatChain->AttackCard()->ID() == "ROS076" && DelimStringContains(CardType($cardID), "I") && $currentPlayer == $mainPlayer) {


### PR DESCRIPTION
CanPlayAsInstant now checks UniqueID (only relevant for Chain Reaction right now).

Chain Reaction code is in, creates new turn effect tagged as HNT253-$uniqueID so that we track the right arsenal card.