### PR TITLE
Sand cover refactor

### DIFF
--- a/CardDictionaries/Uprising/UPRIllusionist.php
+++ b/CardDictionaries/Uprising/UPRIllusionist.php
@@ -3,6 +3,13 @@
   function UPRIllusionistPlayAbility($cardID, $from, $resourcesPaid, $target, $additionalCosts)
   {
     global $currentPlayer;
+    $perms = &GetPermanents($currentPlayer);
+    $targetIndex = explode("-", $target)[1];
+    $matID = explode(",", $perms[$targetIndex])[0];
+    if ($matID == "UPR439" || $matID == "UPR440" || $matID == "UPR441") {
+      $origMaterial = explode(",", $perms[$targetIndex])[1];
+      ResolveTransformPermanent($currentPlayer, $targetIndex, $origMaterial);
+    }
     switch($cardID)
     {
       case "UPR004": Transform($currentPlayer, "Ash", "UPR042", target:$target); return "";
@@ -30,16 +37,13 @@
         for($i=0; $i<$maxTransform; ++$i) Transform($currentPlayer, "Ash", "UPR042", true, ($i == 0 ? false : true), ($i == 0 ? false : true));
         return "";
       case "UPR039":
-        $targetIndex = explode("-", $target)[1];
-        ResolveTransformPermanent($currentPlayer, $targetIndex, "UPR439");
+        Transform($currentPlayer, "Ash", "UPR439", target:$target);
         return "";
       case "UPR040":
-        $targetIndex = explode("-", $target)[1];
-        ResolveTransformPermanent($currentPlayer, $targetIndex, "UPR440");
+        Transform($currentPlayer, "Ash", "UPR440", target:$target);
         return "";
       case "UPR041":
-        $targetIndex = explode("-", $target)[1];
-        ResolveTransformPermanent($currentPlayer, $targetIndex, "UPR441");
+        Transform($currentPlayer, "Ash", "UPR441", target:$target);
         return "";
       case "UPR036": case "UPR037": case "UPR038":
         Transform($currentPlayer, "Ash", "UPR042", target:$target);
@@ -115,8 +119,14 @@ function UPRIllusionistDealDamageEffect($cardID)
   {
     if($target != ""){
       $index = explode("-", $target);
-      AddDecisionQueue("PASSPARAMETER", $player, $index[1], 1);
-      AddDecisionQueue("TRANSFORM", $player, $into.",".$firstTransform, 1);
+      if ($into == "UPR439" || $into == "UPR440" || $into == "UPR441") {
+        AddDecisionQueue("PASSPARAMETER", $player, $index[1], 1);
+        AddDecisionQueue("TRANSFORMPERMANENT", $player, $into.",".$firstTransform, 1);
+      }
+      else {
+        AddDecisionQueue("PASSPARAMETER", $player, $index[1], 1);
+        AddDecisionQueue("TRANSFORM", $player, $into.",".$firstTransform, 1);
+      }
     } else if($materialType == "Ash") {
       AddDecisionQueue("FINDINDICES", $player, "PERMSUBTYPE," . $materialType, ($subsequent ? 1 : 0));
       AddDecisionQueue("SETDQCONTEXT", $player, "Choose a material to transform into " . CardLink($into, $into), 1);
@@ -146,8 +156,8 @@ function UPRIllusionistDealDamageEffect($cardID)
 
   function ResolveTransformPermanent($player, $materialIndex, $into)
   {
-    RemovePermanent($player, $materialIndex);
-    return PutPermanentIntoPlay($player, $into);
+    $materialType = RemovePermanent($player, $materialIndex);
+    return PutPermanentIntoPlay($player, $into, subCards: $materialType);
   }
 
   function ResolveTransformAura($player, $materialIndex, $into)

--- a/CardDictionaries/Uprising/UPRIllusionist.php
+++ b/CardDictionaries/Uprising/UPRIllusionist.php
@@ -29,9 +29,12 @@
         else $maxTransform = 1;
         for($i=0; $i<$maxTransform; ++$i) Transform($currentPlayer, "Ash", "UPR042", true, ($i == 0 ? false : true), ($i == 0 ? false : true));
         return "";
-      case "UPR039": TransformPermanent($currentPlayer, "Ash", "UPR439"); return "";
-      case "UPR040": TransformPermanent($currentPlayer, "Ash", "UPR440"); return "";
-      case "UPR041": TransformPermanent($currentPlayer, "Ash", "UPR441"); return "";
+      case "UPR039":
+      case "UPR040":
+      case "UPR041":
+        $targetIndex = explode("-", $target)[1];
+        ResolveTransformPermanent($currentPlayer, $targetIndex, $cardID);
+        return "";
       case "UPR036": case "UPR037": case "UPR038":
         Transform($currentPlayer, "Ash", "UPR042", target:$target);
         AddDecisionQueue("MZOP", $currentPlayer, "GETUNIQUEID");
@@ -133,15 +136,6 @@ function UPRIllusionistDealDamageEffect($cardID)
   {
     $materialType = RemovePermanent($player, $materialIndex);
     return PlayAlly($into, $player, $materialType, firstTransform: $firstTransform);
-  }
-
-  function TransformPermanent($player, $materialType, $into, $optional=false)
-  {
-    AddDecisionQueue("FINDINDICES", $player, "PERMSUBTYPE," . $materialType);
-    AddDecisionQueue("SETDQCONTEXT", $player, "Choose a material to transform", 1);
-    if($optional) AddDecisionQueue("MAYCHOOSEPERMANENT", $player, "<-", 1);
-    else AddDecisionQueue("CHOOSEPERMANENT", $player, "<-", 1);
-    AddDecisionQueue("TRANSFORMPERMANENT", $player, $into, 1);
   }
 
   function ResolveTransformPermanent($player, $materialIndex, $into)

--- a/CardDictionaries/Uprising/UPRIllusionist.php
+++ b/CardDictionaries/Uprising/UPRIllusionist.php
@@ -3,12 +3,14 @@
   function UPRIllusionistPlayAbility($cardID, $from, $resourcesPaid, $target, $additionalCosts)
   {
     global $currentPlayer;
-    $perms = &GetPermanents($currentPlayer);
+    $permanents = &GetPermanents($currentPlayer);
     $targetIndex = explode("-", $target)[1];
-    $matID = explode(",", $perms[$targetIndex])[0];
-    if ($matID == "UPR439" || $matID == "UPR440" || $matID == "UPR441") {
-      $origMaterial = explode(",", $perms[$targetIndex])[1];
-      ResolveTransformPermanent($currentPlayer, $targetIndex, $origMaterial);
+    $matID = $permanents[$targetIndex];
+    if ($matID == "UPR439" || $matID == "UPR440" || $matID == "UPR441") { //untransform sand cover
+      $origMaterial = explode(",", $permanents[$targetIndex+2])[0];
+      DestroyPermanent($currentPlayer, $targetIndex);
+      $targetIndex = PutPermanentIntoPlay($currentPlayer, $origMaterial);
+      $target = "MYPERM-$targetIndex";
     }
     switch($cardID)
     {
@@ -121,7 +123,7 @@ function UPRIllusionistDealDamageEffect($cardID)
       $index = explode("-", $target);
       if ($into == "UPR439" || $into == "UPR440" || $into == "UPR441") {
         AddDecisionQueue("PASSPARAMETER", $player, $index[1], 1);
-        AddDecisionQueue("TRANSFORMPERMANENT", $player, $into.",".$firstTransform, 1);
+        AddDecisionQueue("TRANSFORMPERMANENT", $player, $into, 1);
       }
       else {
         AddDecisionQueue("PASSPARAMETER", $player, $index[1], 1);

--- a/CardDictionaries/Uprising/UPRIllusionist.php
+++ b/CardDictionaries/Uprising/UPRIllusionist.php
@@ -30,10 +30,16 @@
         for($i=0; $i<$maxTransform; ++$i) Transform($currentPlayer, "Ash", "UPR042", true, ($i == 0 ? false : true), ($i == 0 ? false : true));
         return "";
       case "UPR039":
+        $targetIndex = explode("-", $target)[1];
+        ResolveTransformPermanent($currentPlayer, $targetIndex, "UPR439");
+        return "";
       case "UPR040":
+        $targetIndex = explode("-", $target)[1];
+        ResolveTransformPermanent($currentPlayer, $targetIndex, "UPR440");
+        return "";
       case "UPR041":
         $targetIndex = explode("-", $target)[1];
-        ResolveTransformPermanent($currentPlayer, $targetIndex, $cardID);
+        ResolveTransformPermanent($currentPlayer, $targetIndex, "UPR441");
         return "";
       case "UPR036": case "UPR037": case "UPR038":
         Transform($currentPlayer, "Ash", "UPR042", target:$target);

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -190,9 +190,9 @@ function CardSubType($cardID, $uniqueID = -1)
   switch ($cardID) {
     case "ROS027"://Technically false, but helps with Rosetta Limited
       return "Item";
-    case "UPR039":
-    case "UPR040":
-    case "UPR041": //Technically false, but maintains targetted ash as ash
+    case "UPR439":
+    case "UPR440":
+    case "UPR441": //resolved sand cover
       return "Ash";
     default:
       break;

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -190,6 +190,10 @@ function CardSubType($cardID, $uniqueID = -1)
   switch ($cardID) {
     case "ROS027"://Technically false, but helps with Rosetta Limited
       return "Item";
+    case "UPR039":
+    case "UPR040":
+    case "UPR041": //Technically false, but maintains targetted ash as ash
+      return "Ash";
     default:
       break;
   }

--- a/Constants.php
+++ b/Constants.php
@@ -169,7 +169,7 @@ function AllyPieces()
 //1 - Where it's played from
 function PermanentPieces()
 {
-  return 2;
+  return 3;
 }
 
 //0 - Card ID/Layer type

--- a/Constants.php
+++ b/Constants.php
@@ -167,6 +167,7 @@ function AllyPieces()
 
 //0 - Card ID
 //1 - Where it's played from
+//2 - Subcards , delimited
 function PermanentPieces()
 {
   return 3;

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -1779,6 +1779,7 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
       $params = explode(",", $parameter);
       return "ALLY-" . ResolveTransform($player, $lastResult, $params[0], $params[1]);
     case "TRANSFORMPERMANENT":
+      $params = explode(",", $parameter);
       return "PERMANENT-" . ResolveTransformPermanent($player, $lastResult, $parameter);
     case "TRANSFORMAURA":
       return "AURA-" . ResolveTransformAura($player, $lastResult, $parameter);

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -1826,6 +1826,14 @@ function GetLayerTarget($cardID, $from)
       AddDecisionQueue("CHOOSEMULTIZONE", $currentPlayer, "<-", 1);
       AddDecisionQueue("SETLAYERTARGET", $currentPlayer, $cardID, 1);
       break;
+    case "UPR039": //sand cover
+    case "UPR040":
+    case "UPR041":
+      AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "MYPERM:subtype=Ash");
+      AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose an Ash to grant ward");
+      AddDecisionQueue("CHOOSEMULTIZONE", $currentPlayer, "<-", 1);
+      AddDecisionQueue("SETLAYERTARGET", $currentPlayer, $cardID, 1);
+      break;
     case "UPR183":
       AddDecisionQueue("FINDINDICES", $currentPlayer, "DAMAGEPREVENTIONTARGET");
       AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a damage source for Helio's Mitre");

--- a/PermanentAbilities.php
+++ b/PermanentAbilities.php
@@ -1,6 +1,6 @@
 <?php
 
-function PutPermanentIntoPlay($player, $cardID, $number=1, $isToken=false, $from="-")
+function PutPermanentIntoPlay($player, $cardID, $number=1, $isToken=false, $from="-", $subCards="-")
 {
   global $EffectContext;
   $permanents = &GetPermanents($player);
@@ -12,6 +12,7 @@ function PutPermanentIntoPlay($player, $cardID, $number=1, $isToken=false, $from
   for($i = 0; $i < $number; ++$i) {
     array_push($permanents, $cardID);
     array_push($permanents, $from);
+    array_push($permanents, $subCards);
   }
   return count($permanents) - PermanentPieces();
 }
@@ -65,7 +66,8 @@ function PermanentBeginEndPhaseEffects()
     $remove = 0;
     switch ($permanents[$i]) {
       case "UPR439": case "UPR440": case "UPR441":
-        PutPermanentIntoPlay($mainPlayer, "UPR043");
+        $origMaterial = $permanents[$i+2];
+        if ($origMaterial != "-") PutPermanentIntoPlay($mainPlayer, $origMaterial);
         $remove = 1;
         break;
       case "ROGUE501":
@@ -127,7 +129,8 @@ function PermanentBeginEndPhaseEffects()
     $remove = 0;
     switch ($permanents[$i]) {
       case "UPR439": case "UPR440": case "UPR441":
-        PutPermanentIntoPlay($defPlayer, "UPR043");
+        $origMaterial = $permanents[$i+2];
+        if ($origMaterial != "-") PutPermanentIntoPlay($mainPlayer, $origMaterial);
         $remove = 1;
         break;
       default:

--- a/PermanentAbilities.php
+++ b/PermanentAbilities.php
@@ -147,24 +147,25 @@ function PermanentTakeDamageAbilities($player, $damage, $type, $source)
   $otherPlayer = $player == 1 ? 1 : 2;
   //CR 2.1 6.4.10f If an effect states that a prevention effect can not prevent the damage of an event, the prevention effect still applies to the event but its prevention amount is not reduced. Any additional modifications to the event by the prevention effect still occur.
   $preventable = CanDamageBePrevented($otherPlayer, $damage, $type, $source);
+  $preventedDamage = 0;
   for ($i = count($permanents) - PermanentPieces(); $i >= 0; $i -= PermanentPieces()) {
     $remove = 0;
     switch ($permanents[$i]) {
       case "UPR439":
         if ($damage > 0) {
-          if ($preventable) $damage -= 4;
+          if ($preventable) $preventedDamage += 4;
           $remove = 1;
         }
         break;
       case "UPR440":
         if ($damage > 0) {
-          if ($preventable) $damage -= 3;
+          if ($preventable) $preventedDamage += 3;
           $remove = 1;
         }
         break;
       case "UPR441":
         if ($damage > 0) {
-          if ($preventable) $damage -= 2;
+          if ($preventable) $preventedDamage += 2;
           $remove = 1;
         }
         break;
@@ -181,6 +182,11 @@ function PermanentTakeDamageAbilities($player, $damage, $type, $source)
       DestroyPermanent($player, $i);
     }
   }
+  if (SearchCurrentTurnEffects("OUT174", $player) != "" && $preventedDamage > 0) {//vambrace
+    $preventedDamage -= 1;
+    SearchCurrentTurnEffects("OUT174", $player, remove:true);
+  }
+  $damage -= $preventedDamage;
   if ($damage <= 0) $damage = 0;
   return $damage;
 }

--- a/PermanentAbilities.php
+++ b/PermanentAbilities.php
@@ -9,6 +9,7 @@ function PutPermanentIntoPlay($player, $cardID, $number=1, $isToken=false, $from
   $numMinusTokens = 0;
   $numMinusTokens = CountCurrentTurnEffects("HVY209", $player) + CountCurrentTurnEffects("HVY209", $otherPlayer);
   if($numMinusTokens > 0 && $isToken && (TypeContains($EffectContext, "AA", $player) || TypeContains($EffectContext, "A", $player))) $number -= $numMinusTokens;
+  WriteLog("Here playing permanent: $cardID, $subCards");
   for($i = 0; $i < $number; ++$i) {
     array_push($permanents, $cardID);
     array_push($permanents, $from);
@@ -66,7 +67,7 @@ function PermanentBeginEndPhaseEffects()
     $remove = 0;
     switch ($permanents[$i]) {
       case "UPR439": case "UPR440": case "UPR441":
-        $origMaterial = $permanents[$i+2];
+        $origMaterial = explode(",", $permanents[$i+2])[0];
         if ($origMaterial != "-") PutPermanentIntoPlay($mainPlayer, $origMaterial);
         $remove = 1;
         break;
@@ -129,8 +130,8 @@ function PermanentBeginEndPhaseEffects()
     $remove = 0;
     switch ($permanents[$i]) {
       case "UPR439": case "UPR440": case "UPR441":
-        $origMaterial = $permanents[$i+2];
-        if ($origMaterial != "-") PutPermanentIntoPlay($mainPlayer, $origMaterial);
+        $origMaterial = explode(",", $permanents[$i+2])[0];
+        if ($origMaterial != "-") PutPermanentIntoPlay($defPlayer, $origMaterial);
         $remove = 1;
         break;
       default:

--- a/PermanentAbilities.php
+++ b/PermanentAbilities.php
@@ -9,7 +9,6 @@ function PutPermanentIntoPlay($player, $cardID, $number=1, $isToken=false, $from
   $numMinusTokens = 0;
   $numMinusTokens = CountCurrentTurnEffects("HVY209", $player) + CountCurrentTurnEffects("HVY209", $otherPlayer);
   if($numMinusTokens > 0 && $isToken && (TypeContains($EffectContext, "AA", $player) || TypeContains($EffectContext, "A", $player))) $number -= $numMinusTokens;
-  WriteLog("Here playing permanent: $cardID, $subCards");
   for($i = 0; $i < $number; ++$i) {
     array_push($permanents, $cardID);
     array_push($permanents, $from);


### PR DESCRIPTION
a refactor of how sand cover works to allow you to invoke dragons over it
It mostly involves 2 things:
1. targeting now happens when playing the card, not on resolution, code copied from dragon invocations
2. added a new piece to permanents to track what card it was originally so when a dragon is invoked over it, the ash will return to normal.
As a consequence of the above, sand cover now works with the "dust from X" ashes

I removed the "TransformPermanent" since that was just handling ash selection which is now handled by targeting

Also added vambrace logic to sand cover