### PR TITLE
Add character data to game result

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -485,6 +485,7 @@ function SerializeGameResult($player, $DeckLink, $deckAfterSB, $gameID = "", $op
 		$cardResult = [
 			"cardId" => GetNormalCardID($card),
 			"cardName" => CardName($card),
+			"numCopies" => $numCopies,
 		];
 		array_push($deck["character"], $cardResult);
 	}

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -454,6 +454,7 @@ function SerializeGameResult($player, $DeckLink, $deckAfterSB, $gameID = "", $op
 	}
 	$deckAfterSB = explode("\r\n", $deckAfterSB);
 	if(count($deckAfterSB) == 1) return "";
+	$character = $deckAfterSB[0];
 	$deckAfterSB = $deckAfterSB[1];
 	$deck = [];
 	if($gameID != "") $deck["gameId"] = $gameID;
@@ -465,23 +466,56 @@ function SerializeGameResult($player, $DeckLink, $deckAfterSB, $gameID = "", $op
 	if($opposingHero != "") $deck["opposingHero"] = $opposingHero;
 	if($deckbuilderID != "") $deck["deckbuilderID"] = $deckbuilderID;
 	$deck["cardResults"] = [];
+	$deck["character"] = [];
+
+	$character = explode(" ", $character);
+	$deduplicatedCharacter = [];
+	for($i = 0; $i < count($character); ++$i) {
+		$card = $character[$i];
+
+		if (array_key_exists($card, $deduplicatedCharacter)) {
+			$deduplicatedCharacter[$card]++;
+		} else {
+			$deduplicatedCharacter[$card] = 1;
+		}
+	}
+	$deck["character"] = [];
+
+	foreach ($deduplicatedCharacter as $card => $numCopies) {
+		$cardResult = [
+			"cardId" => GetNormalCardID($card),
+			"cardName" => CardName($card),
+		];
+		array_push($deck["character"], $cardResult);
+	}
+
 	$deckAfterSB = explode(" ", $deckAfterSB);
 	$deduplicatedDeck = [];
 	for($i = 0; $i < count($deckAfterSB); ++$i) {
-		if($i > 0 && $deckAfterSB[$i] == $deckAfterSB[$i - 1]) continue; //Don't send duplicates
-		array_push($deduplicatedDeck, $deckAfterSB[$i]);
+		$card = $deckAfterSB[$i];
+
+		if (array_key_exists($card, $deduplicatedDeck)) {
+			$deduplicatedDeck[$card]++;
+		} else {
+			$deduplicatedDeck[$card] = 1;
+		}
 	}
-	for ($i = 0; $i < count($deduplicatedDeck); ++$i) {
-		$deck["cardResults"][$i] = [];
-		$deck["cardResults"][$i]["cardId"] = GetNormalCardID($deduplicatedDeck[$i]);
-		$deck["cardResults"][$i]["played"] = 0;
-		$deck["cardResults"][$i]["blocked"] = 0;
-		$deck["cardResults"][$i]["pitched"] = 0;
-		$deck["cardResults"][$i]["hits"] = 0;
-		$deck["cardResults"][$i]["charged"] = 0;
-		$deck["cardResults"][$i]["cardName"] = CardName($deduplicatedDeck[$i]);
-		$deck["cardResults"][$i]["pitchValue"] = PitchValue($deduplicatedDeck[$i]);
+
+	foreach ($deduplicatedDeck as $card => $numCopies) {
+		$cardResult = [
+			"cardId" => GetNormalCardID($card),
+			"played" => 0,
+			"blocked" => 0,
+			"pitched" => 0,
+			"hits" => 0,
+			"charged" => 0,
+			"cardName" => CardName($card),
+			"pitchValue" => PitchValue($card),
+			"numCopies" => $numCopies,
+		];
+		array_push($deck["cardResults"], $cardResult);
 	}
+
 	$cardStats = &GetCardStats($player);
 	for($i = 0; $i < count($cardStats); $i += CardStatPieces()) {
 		for($j = 0; $j < count($deck["cardResults"]); ++$j) {


### PR DESCRIPTION
This PR updates the SerializeGameResult function:
- Adds a new key: "character" which contains equipment, weapon, and hero cards
- Adds a new key "numCopies" to the "cardResults" array

Previously, when using `zzGameStatsAPI.php` there was no easy way to determine what hero or equipment was played for a particular match or how many copies of a card was registered for a sideboard. The additional data is useful when aggregating internal team testing data.

I did my best to not make this a breaking change by adding new keys, and not changing existing ones. I'm not experienced with the codebase, so let me know if this is problematic.

# Original Sample:
```
{
    "averageCardsLeftOverPerTurn": 0,
    "averageCombatValuePerTurn": 0,
    "averageDamageDealtPerTurn": 0,
    "averageDamageThreatenedPerCard": 0,
    "averageDamageThreatenedPerTurn": 0,
    "averageResourcesUsedPerTurn": 0,
    "averageValuePerTurn": 0,
    "cardResults": [
        {
            "blocked": 0,
            "cardId": "ARC081",
            "cardName": "Mordred Tide",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC082",
            "cardName": "Ninth Blade of the Blood Oath",
            "charged": 0,
            "hits": 0,
            "pitchValue": 2,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC083",
            "cardName": "Become the Arknight",
            "charged": 0,
            "hits": 0,
            "pitchValue": 3,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC094",
            "cardName": "Amplify the Arknight",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC095",
            "cardName": "Amplify the Arknight",
            "charged": 0,
            "hits": 0,
            "pitchValue": 2,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC097",
            "cardName": "Drawn to the Dark Dimension",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC100",
            "cardName": "Rune Flash",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC101",
            "cardName": "Rune Flash",
            "charged": 0,
            "hits": 0,
            "pitchValue": 2,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "CRU143",
            "cardName": "Rattle Bones",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "DTD213",
            "cardName": "Runic Reckoning",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "DYN179",
            "cardName": "Blessing of Occult",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "EVR105",
            "cardName": "Swarming Gloomveil",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "EVR106",
            "cardName": "Revel in Runeblood",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "HVY251",
            "cardName": "Sonata Galaxia",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ROS130",
            "cardName": "Malefic Incantation",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ROS131",
            "cardName": "Malefic Incantation",
            "charged": 0,
            "hits": 0,
            "pitchValue": 2,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ROS149",
            "cardName": "Runerager Swarm",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ROS150",
            "cardName": "Runerager Swarm",
            "charged": 0,
            "hits": 0,
            "pitchValue": 2,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ROS155",
            "cardName": "Deadwood Dirge",
            "charged": 0,
            "hits": 0,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        }
    ],
    "deckId": "",
    "firstPlayer": 1,
    "gameId": "127",
    "result": 0,
    "totalDamageDealt": 0,
    "totalDamagePrevented": 0,
    "totalDamageThreatened": 0,
    "totalLifeGained": 0,
    "totalTime": 0,
    "turnResults": [
        {
            "cardsBlocked": "0",
            "cardsLeft": "0",
            "cardsPitched": "0",
            "cardsUsed": 0,
            "damageBlocked": "0",
            "damageDealt": "0",
            "damagePrevented": "0",
            "damageTaken": "0",
            "damageThreatened": "0",
            "lifeGained": "0",
            "resourcesLeft": "0",
            "resourcesUsed": "0"
        }
    ],
    "turns": 1,
    "yourTime": "0"
}
```

# Updated Sample:
```
{
    "averageCardsLeftOverPerTurn": 0,
    "averageCombatValuePerTurn": 0,
    "averageDamageDealtPerTurn": 0,
    "averageDamageThreatenedPerCard": 0,
    "averageDamageThreatenedPerTurn": 0,
    "averageResourcesUsedPerTurn": 0,
    "averageValuePerTurn": 0,
    "cardResults": [
        {
            "blocked": 0,
            "cardId": "ARC081",
            "cardName": "Mordred Tide",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC082",
            "cardName": "Ninth Blade of the Blood Oath",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 2,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC083",
            "cardName": "Become the Arknight",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 3,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC094",
            "cardName": "Amplify the Arknight",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC095",
            "cardName": "Amplify the Arknight",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 2,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC097",
            "cardName": "Drawn to the Dark Dimension",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC100",
            "cardName": "Rune Flash",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ARC101",
            "cardName": "Rune Flash",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 2,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "CRU143",
            "cardName": "Rattle Bones",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "DTD213",
            "cardName": "Runic Reckoning",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "DYN179",
            "cardName": "Blessing of Occult",
            "charged": 0,
            "hits": 0,
            "numCopies": 1,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "EVR105",
            "cardName": "Swarming Gloomveil",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "EVR106",
            "cardName": "Revel in Runeblood",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "HVY251",
            "cardName": "Sonata Galaxia",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ROS130",
            "cardName": "Malefic Incantation",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ROS131",
            "cardName": "Malefic Incantation",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 2,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ROS149",
            "cardName": "Runerager Swarm",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ROS150",
            "cardName": "Runerager Swarm",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 2,
            "pitched": 0,
            "played": 0
        },
        {
            "blocked": 0,
            "cardId": "ROS155",
            "cardName": "Deadwood Dirge",
            "charged": 0,
            "hits": 0,
            "numCopies": 3,
            "pitchValue": 1,
            "pitched": 0,
            "played": 0
        }
    ],
    "character": [
        {
            "cardId": "ARC075",
            "cardName": "Viserai, Rune Blood",
            "numCopies": 1
        },
        {
            "cardId": "CRU140",
            "cardName": "Reaping Blade",
            "numCopies": 1
        },
        {
            "cardId": "UPR182",
            "cardName": "Crown of Providence",
            "numCopies": 1
        },
        {
            "cardId": "DTD211",
            "cardName": "Dyadic Carapace",
            "numCopies": 1
        },
        {
            "cardId": "ARC078",
            "cardName": "Grasp of the Arknight",
            "numCopies": 1
        },
        {
            "cardId": "ELE224",
            "cardName": "Spellbound Creepers",
            "numCopies": 1
        }
    ],
    "deckId": "",
    "firstPlayer": 1,
    "gameId": "127",
    "result": 0,
    "totalDamageDealt": 0,
    "totalDamagePrevented": 0,
    "totalDamageThreatened": 0,
    "totalLifeGained": 0,
    "totalTime": 0,
    "turnResults": [
        {
            "cardsBlocked": "0",
            "cardsLeft": "0",
            "cardsPitched": "0",
            "cardsUsed": 0,
            "damageBlocked": "0",
            "damageDealt": "0",
            "damagePrevented": "0",
            "damageTaken": "0",
            "damageThreatened": "0",
            "lifeGained": "0",
            "resourcesLeft": "0",
            "resourcesUsed": "0"
        }
    ],
    "turns": 1,
    "yourTime": "0"
}
```