### PR TITLE
Graphene

### DIFF
--- a/CardDictionaries/Hunted/HNTShared.php
+++ b/CardDictionaries/Hunted/HNTShared.php
@@ -42,7 +42,6 @@ function HNTAbilityHasGoAgain($cardID): bool
   global $currentPlayer;
   $defPlayer = $currentPlayer == 1 ? 2 : 1;
   return match ($cardID) {
-    "HNT053" => IsHeroAttackTarget() && CheckMarked($defPlayer),
     default => false,
   };
 }

--- a/CardDictionaries/Hunted/HNTShared.php
+++ b/CardDictionaries/Hunted/HNTShared.php
@@ -9,6 +9,7 @@ function HNTAbilityType($cardID): string
     "HNT006" => "AR",
     "HNT007" => "AR",
     "HNT010" => "AA",
+    "HNT053" => "AA",
     "HNT054" => "I",
     "HNT055" => "I",
     "HNT056" => "AA",
@@ -25,6 +26,7 @@ function HNTAbilityCost($cardID): int
   global $currentPlayer, $mainPlayer;
   return match ($cardID) {
     "HNT010" => 2,
+    "HNT053" => 1,
     "HNT054" => 3 - ($mainPlayer == $currentPlayer ? NumDraconicChainLinks() : 0),
     "HNT055" => 3 - ($mainPlayer == $currentPlayer ? NumDraconicChainLinks() : 0),
     "HNT056" => 1,
@@ -37,7 +39,10 @@ function HNTAbilityCost($cardID): int
 
 function HNTAbilityHasGoAgain($cardID): bool
 {
+  global $currentPlayer;
+  $defPlayer = $currentPlayer == 1 ? 2 : 1;
   return match ($cardID) {
+    "HNT053" => IsHeroAttackTarget() && CheckMarked($defPlayer),
     default => false,
   };
 }
@@ -109,7 +114,7 @@ function HNTPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
       if (HasStealth($CombatChain->AttackCard()->ID())) AddCurrentTurnEffect("$cardID-HIT", $currentPlayer);
       break;
     case "HNT005":
-      WriteLog("We don't know what Graphene Chelicera is yet");
+      EquipEquipment($currentPlayer, "HNT053");
       AddCurrentTurnEffect($cardID, $currentPlayer);
       break;
     case "HNT006":

--- a/CardDictionaries/Hunted/HNTShared.php
+++ b/CardDictionaries/Hunted/HNTShared.php
@@ -114,7 +114,7 @@ function HNTPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
       if (HasStealth($CombatChain->AttackCard()->ID())) AddCurrentTurnEffect("$cardID-HIT", $currentPlayer);
       break;
     case "HNT005":
-      EquipEquipment($currentPlayer, "HNT053");
+      EquipWeapon($currentPlayer, "HNT053");
       AddCurrentTurnEffect($cardID, $currentPlayer);
       break;
     case "HNT006":

--- a/CardDictionaries/Outsiders/OUTShared.php
+++ b/CardDictionaries/Outsiders/OUTShared.php
@@ -733,7 +733,7 @@ function OUTAbilityCost($cardID)
       case "MST121": case "MST122": case "MST123": 
       case "MST124": case "MST125": case "MST126":
       case "MST127": case "MST128": case "MST129":
-      case "HNT030": case "HNT031":
+      case "HNT030": case "HNT031": case "HNT053":
         return true;
       default:
         return false;

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -80,6 +80,9 @@ function CardType($cardID, $from="")
       return "Macro";
     case "AJV002":
       return "W";
+    case "HNT053":
+      // this is incorrect for Down but not Out, but is needed for now
+      return "W";
     default:
       break;
   }

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -815,7 +815,7 @@ function AttackValue($cardID, $index=-1)
   if ($cardID == "HVY049") return GetClassState($mainPlayer, $CS_NumCardsDrawn) >= 1 ? 4 : 3;
   if ($cardID == "ROS003") return (GetClassState($mainPlayer, $CS_NumAuras) > 0 ? 4 : 2);
   if ($cardID == "HNT010") {
-    if ($currentPlayer != $mainPlayer || !IsHeroAttackTarget()) return 1;
+    if (!IsHeroAttackTarget()) return 1;
     else return CheckMarked($defPlayer) ? 2 : 1;
   }
   if ($class == "ILLUSIONIST" && DelimStringContains($subtype, "Aura")) {

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -890,10 +890,6 @@ function AddOnHitTrigger($cardID, $uniqueID = -1): void
       AddLayer("TRIGGER", $mainPlayer, substr($cardID, 0, 6), $cardID, "ONHITEFFECT");
       break;
     case "HNT010":
-      $char = GetPlayerCharacter($mainPlayer);
-      for ($i = 0; $i < count($char); $i += CharacterPieces()) {
-        WriteLog($char[$i] . "-" . $char[$i+11]);
-      }
       AddLayer("TRIGGER", $mainPlayer, substr($cardID, 0, 6), $cardID, "ONHITEFFECT", $uniqueID);
       break;
     case "CRU054":

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -1727,6 +1727,8 @@ function DoesAttackHaveGoAgain()
       return GetClassState($mainPlayer, $CS_NumAuras) > 0;
     case "ROS245":
       return ComboActive($attackID);
+    case "HNT053":
+      return IsHeroAttackTarget() && CheckMarked($defPlayer);
     case "HNT071":
       return SearchCurrentTurnEffects("HNT071", $mainPlayer);
     case "HNT249":

--- a/GeneratedCode/GeneratedCardDictionaries.php
+++ b/GeneratedCode/GeneratedCardDictionaries.php
@@ -5017,6 +5017,8 @@ case "5":
 return "C";
 case "4":
 return "C";
+case "3":
+return "T";
 case "6":
 return "W";
 default: return "AA";
@@ -6941,6 +6943,8 @@ case "5":
 switch($cardID[5]) {
 case "7":
 return 2;
+case "3":
+return 1;
 case "6":
 return 1;
 default: return 0;
@@ -15867,21 +15871,13 @@ case "2":
 return -1;
 default: return 3;
 }
-case "7":
-switch($cardID[5]) {
-case "4":
-return -1;
-case "5":
-return -1;
-case "6":
-return -1;
-default: return 3;
-}
 case "5":
 switch($cardID[5]) {
 case "5":
 return -1;
 case "4":
+return -1;
+case "3":
 return -1;
 case "6":
 return -1;
@@ -24493,6 +24489,8 @@ case "5":
 return "Cindra";
 case "4":
 return "Cindra, Dracai of Retribution";
+case "3":
+return "Graphene Chelicera";
 case "6":
 return "Kunai of Retribution";
 default: return "";
@@ -33101,6 +33099,8 @@ case "5":
 return 0;
 case "4":
 return 0;
+case "3":
+return 0;
 case "6":
 return 0;
 default: return 1;
@@ -40375,6 +40375,8 @@ case "5":
 return -1;
 case "4":
 return -1;
+case "3":
+return -1;
 case "6":
 return -1;
 default: return 0;
@@ -46233,6 +46235,8 @@ case "5":
 return "Royal,Young";
 case "4":
 return "Royal";
+case "3":
+return "Dagger";
 case "6":
 return "Dagger";
 default: return "";
@@ -52427,6 +52431,8 @@ case "5":
 return "T";
 case "4":
 return "M";
+case "3":
+return "T";
 case "6":
 return "T";
 default: return "C";
@@ -53857,6 +53863,7 @@ case "CRU080": return true;
 case "HVY094": return true;
 case "DTD135": return true;
 case "JDG005": return true;
+case "HNT053": return true;
 case "HVY245": return true;
 case "TCC028": return true;
 case "CRU048": return true;
@@ -59288,6 +59295,8 @@ case "5":
 return "NINJA";
 case "4":
 return "NINJA";
+case "3":
+return "ASSASSIN";
 case "6":
 return "NINJA";
 default: return "NONE";
@@ -67395,6 +67404,7 @@ case "MST008": return "false";
 case "HVY097": return "false";
 case "EVR000": return "false";
 case "HVY205": return "false";
+case "HNT053": return "false";
 case "DTD167": return "false";
 case "ARC078": return "false";
 case "MST200": return "false";


### PR DESCRIPTION
It looks like right now talishar does not support a card being both a token and a weapon, so I've set graphene chelicera to just be a weapon. I believe the only interaction this would mess with at the moment is Down but not Out.
Includes a pull from fabcube that should also fix the arts of dragon block values. Does not include image for chelicera