### PR TITLE
Counting flicked damage

### DIFF
--- a/APIs/SubmitSideboard.php
+++ b/APIs/SubmitSideboard.php
@@ -133,7 +133,7 @@ if($p1SideboardSubmitted == "1" && $p2SideboardSubmitted == "1") {
   fwrite($handler, "M 1\r\n"); //What phase/player is active
   fwrite($handler, "1\r\n"); //Action points
   fwrite($handler, "\r\n"); //Combat Chain
-  fwrite($handler, "0 0 0 0 0 0 0 GY NA 0 0 0 0 0 0 0 NA 0 0 -1 -1 NA 0 0 0 -1 0 0 0 0 - 0 0 0 0 0 0 0 0 0 0\r\n"); //Combat Chain State
+  fwrite($handler, "0 0 0 0 0 0 0 GY NA 0 0 0 0 0 0 0 NA 0 0 -1 -1 NA 0 0 0 -1 0 0 0 0 - 0 0 0 0 0 0 0 0 0 0 0\r\n"); //Combat Chain State
   fwrite($handler, "\r\n"); //Current Turn Effects
   fwrite($handler, "\r\n"); //Current Turn Effects From Combat
   fwrite($handler, "\r\n"); //Next Turn Effects

--- a/CardDictionaries/Outsiders/OUTShared.php
+++ b/CardDictionaries/Outsiders/OUTShared.php
@@ -753,12 +753,12 @@ function OUTAbilityCost($cardID)
     AddDecisionQueue("PREPENDLASTRESULT", $currentPlayer, "1-", 1);
     AddDecisionQueue("APPENDLASTRESULT", $currentPlayer, "-DAMAGE", 1);
     AddDecisionQueue("DEALDAMAGE", $otherPlayer, "<-", 1);
+    AddDecisionQueue("INCREMENTCOMBATCHAINSTATEBY", $currentPlayer, $CCS_FlickedDamage, 1);
     AddDecisionQueue("LESSTHANPASS", $currentPlayer, "1", 1);
     AddDecisionQueue("PASSPARAMETER", $currentPlayer, "{1}", 1);
     AddDecisionQueue("ONHITEFFECT", $otherPlayer, $source, 1);
     AddDecisionQueue("PASSPARAMETER", $currentPlayer, "1", 1);
     AddDecisionQueue("SETCOMBATCHAINSTATE", $currentPlayer, $CCS_HitThisLink, 1);
-    AddDecisionQueue("INCREMENTCOMBATCHAINSTATE", $currentPlayer, $CCS_FlickedDamage, 1);
   }
 
   function DamageDealtBySubtype($subtype)

--- a/CardDictionaries/Outsiders/OUTShared.php
+++ b/CardDictionaries/Outsiders/OUTShared.php
@@ -499,7 +499,7 @@ function OUTAbilityCost($cardID)
   {
     global $mainPlayer, $defPlayer, $chainLinks, $chainLinkSummary;
     global $CID_BloodRotPox, $CID_Frailty, $CID_Inertia;
-    global $combatChainState, $CCS_GoesWhereAfterLinkResolves;
+    global $combatChainState, $CCS_GoesWhereAfterLinkResolves, $CCS_FlickedDamage;
     switch ($cardID)
     {
       case "OUT005": case "OUT006":
@@ -629,6 +629,7 @@ function OUTAbilityCost($cardID)
         {
           if(CardSubType($chainLinks[$i][0]) == "Dagger" && $chainLinkSummary[$i*ChainLinkSummaryPieces()] > 0) ++$numDaggerHits;
         }
+        $numDaggerHits += $combatChainState[$CCS_FlickedDamage];
         if($numDaggerHits > 0) WriteLog("Player " . $defPlayer . " lost " . $numDaggerHits . " life from " . CardLink("OUT142", "OUT142"));
         LoseHealth($numDaggerHits, $defPlayer);
         break;
@@ -742,7 +743,7 @@ function OUTAbilityCost($cardID)
 
   function ThrowWeapon($subtype, $source)
   {
-    global $currentPlayer, $CCS_HitThisLink;
+    global $currentPlayer, $CCS_HitThisLink, $CCS_FlickedDamage;
     $otherPlayer = ($currentPlayer == 1 ? 2 : 1);
     AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "MYCHAR:subtype=" . $subtype);
     AddDecisionQueue("REMOVEINDICESIFACTIVECHAINLINK", $currentPlayer, "<-", 1);
@@ -757,16 +758,18 @@ function OUTAbilityCost($cardID)
     AddDecisionQueue("ONHITEFFECT", $otherPlayer, $source, 1);
     AddDecisionQueue("PASSPARAMETER", $currentPlayer, "1", 1);
     AddDecisionQueue("SETCOMBATCHAINSTATE", $currentPlayer, $CCS_HitThisLink, 1);
+    AddDecisionQueue("INCREMENTCOMBATCHAINSTATE", $currentPlayer, $CCS_FlickedDamage, 1);
   }
 
   function DamageDealtBySubtype($subtype)
   {
-    global $chainLinks, $chainLinkSummary;
+    global $chainLinks, $chainLinkSummary, $combatChainState, $CCS_FlickedDamage;
     $damage = 0;
     for($i=0; $i<count($chainLinks); ++$i)
     {
       if(CardSubType($chainLinks[$i][0]) == $subtype) $damage += $chainLinkSummary[$i*ChainLinkSummaryPieces()];
     }
+    if ($subtype == "Dagger") $damage += $combatChainState[$CCS_FlickedDamage];
     return $damage;
   }
 

--- a/Constants.php
+++ b/Constants.php
@@ -383,6 +383,7 @@ $CCS_RequiredNegCounterEquipmentBlock = 37;
 $CCS_NumInstantsPlayedByAttackingPlayer = 38;
 $CCS_NextInstantBouncesAura = 39;
 $CCS_EclecticMag = 40;
+$CCS_FlickedDamage = 41;
 //Deprecated
 //$CCS_ChainAttackBuff -- Use persistent combat effect with RemoveEffectsFromCombatChain instead
 
@@ -395,7 +396,7 @@ function ResetCombatChainState()
   global $CCS_CachedTotalAttack, $CCS_CachedTotalBlock, $CCS_CombatDamageReplaced, $CCS_AttackUniqueID, $CCS_RequiredEquipmentBlock, $CCS_RequiredNegCounterEquipmentBlock;
   global $mainPlayer, $defPlayer, $CCS_CachedDominateActive, $CCS_IsBoosted, $CCS_AttackTargetUID, $CCS_CachedOverpowerActive, $CSS_CachedNumActionBlocked;
   global $chainLinks, $chainLinkSummary, $CCS_CachedNumDefendedFromHand, $CCS_HitThisLink, $CCS_HasAimCounter, $CCS_AttackNumCharged, $CCS_NumInstantsPlayedByAttackingPlayer; 
-  global $CCS_NextInstantBouncesAura, $CCS_EclecticMag;
+  global $CCS_NextInstantBouncesAura, $CCS_EclecticMag, $CCS_FlickedDamage;
 
   if(count($chainLinks) > 0) WriteLog("The combat chain was closed.");
   $combatChainState[$CCS_CurrentAttackGainedGoAgain] = 0;
@@ -435,6 +436,7 @@ function ResetCombatChainState()
   $combatChainState[$CCS_NumInstantsPlayedByAttackingPlayer] = 0;
   $combatChainState[$CCS_NextInstantBouncesAura] = 0;
   $combatChainState[$CCS_EclecticMag] = 0;
+  $combatChainState[$CCS_FlickedDamage] = 0;
   
   for($i = 0; $i < count($chainLinks); ++$i) {
     for($j = 0; $j < count($chainLinks[$i]); $j += ChainLinksPieces()) {
@@ -488,7 +490,7 @@ function ResetChainLinkState()
   global $CCS_CachedTotalAttack, $CCS_CachedTotalBlock, $CCS_CombatDamageReplaced, $CCS_AttackUniqueID, $CCS_RequiredEquipmentBlock, $CCS_RequiredNegCounterEquipmentBlock;
   global $CCS_CachedDominateActive, $CCS_IsBoosted, $CCS_AttackTargetUID, $CCS_CachedOverpowerActive, $CSS_CachedNumActionBlocked;
   global $CCS_CachedNumDefendedFromHand, $CCS_HitThisLink, $CCS_AttackNumCharged, $CCS_WasRuneGate, $CCS_WagersThisLink, $CCS_PhantasmThisLink, $CCS_NumInstantsPlayedByAttackingPlayer;
-  global $CCS_NextInstantBouncesAura, $CCS_EclecticMag;
+  global $CCS_NextInstantBouncesAura, $CCS_EclecticMag, $CCS_FlickedDamage;
 
   WriteLog("The chain link was closed.");
   $combatChainState[$CCS_CurrentAttackGainedGoAgain] = 0;
@@ -526,6 +528,7 @@ function ResetChainLinkState()
   $combatChainState[$CCS_NumInstantsPlayedByAttackingPlayer] = 0;
   $combatChainState[$CCS_NextInstantBouncesAura] = 0;
   $combatChainState[$CCS_EclecticMag] = 0;
+  $combatChainState[$CCS_FlickedDamage] = 0;
   UnsetChainLinkBanish();
 }
 

--- a/Constants.php
+++ b/Constants.php
@@ -490,7 +490,7 @@ function ResetChainLinkState()
   global $CCS_CachedTotalAttack, $CCS_CachedTotalBlock, $CCS_CombatDamageReplaced, $CCS_AttackUniqueID, $CCS_RequiredEquipmentBlock, $CCS_RequiredNegCounterEquipmentBlock;
   global $CCS_CachedDominateActive, $CCS_IsBoosted, $CCS_AttackTargetUID, $CCS_CachedOverpowerActive, $CSS_CachedNumActionBlocked;
   global $CCS_CachedNumDefendedFromHand, $CCS_HitThisLink, $CCS_AttackNumCharged, $CCS_WasRuneGate, $CCS_WagersThisLink, $CCS_PhantasmThisLink, $CCS_NumInstantsPlayedByAttackingPlayer;
-  global $CCS_NextInstantBouncesAura, $CCS_EclecticMag, $CCS_FlickedDamage;
+  global $CCS_NextInstantBouncesAura, $CCS_EclecticMag;
 
   WriteLog("The chain link was closed.");
   $combatChainState[$CCS_CurrentAttackGainedGoAgain] = 0;
@@ -528,7 +528,6 @@ function ResetChainLinkState()
   $combatChainState[$CCS_NumInstantsPlayedByAttackingPlayer] = 0;
   $combatChainState[$CCS_NextInstantBouncesAura] = 0;
   $combatChainState[$CCS_EclecticMag] = 0;
-  $combatChainState[$CCS_FlickedDamage] = 0;
   UnsetChainLinkBanish();
 }
 

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -1421,6 +1421,9 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
     case "INCREMENTCOMBATCHAINSTATE":
       $combatChainState[$parameter] = $combatChainState[$parameter] + 1;
       return $lastResult;
+    case "INCREMENTCOMBATCHAINSTATEBY":
+      $combatChainState[$parameter] = $combatChainState[$parameter] + $lastResult;
+      return $lastResult;
     case "SETLAYERTARGET":
       global $layers;
       $target = $lastResult;

--- a/Start.php
+++ b/Start.php
@@ -61,7 +61,7 @@ fwrite($handler, "1\r\n"); //Current Turn
 fwrite($handler, "M 1\r\n"); //What phase/player is active
 fwrite($handler, "1\r\n"); //Action points
 fwrite($handler, "\r\n"); //Combat Chain
-fwrite($handler, "0 0 0 0 0 0 0 GY NA 0 0 0 0 0 0 0 NA 0 0 -1 -1 NA 0 0 0 -1 0 0 0 0 - 0 0 0 0 0 0 0 0 0 0\r\n"); //Combat Chain State
+fwrite($handler, "0 0 0 0 0 0 0 GY NA 0 0 0 0 0 0 0 NA 0 0 -1 -1 NA 0 0 0 -1 0 0 0 0 - 0 0 0 0 0 0 0 0 0 0 0\r\n"); //Combat Chain State
 fwrite($handler, "\r\n"); //Current Turn Effects
 fwrite($handler, "\r\n"); //Current Turn Effects From Combat
 fwrite($handler, "\r\n"); //Next Turn Effects


### PR DESCRIPTION
This should fix the bug where stab wound and bleed out weren't tracking flicked damage.
There isn't a check on flicked damage to make sure it's coming from a dagger, but right now that's the only way to throw the weapon