### PR TITLE
Flick hit bug fixing

### DIFF
--- a/CharacterAbilities.php
+++ b/CharacterAbilities.php
@@ -463,7 +463,7 @@ function MainCharacterEndTurnAbilities()
   }
 }
 
-function MainCharacterHitTrigger()
+function MainCharacterHitTrigger($cardID)
 {
   global $CombatChain, $combatChainState, $CCS_WeaponIndex, $mainPlayer;
   $attackID = $CombatChain->AttackCard()->ID();
@@ -540,7 +540,7 @@ function MainCharacterHitTrigger()
         break;
       case "HNT001":
       case "HNT002":
-        if (IsHeroAttackTarget() && CheckMarked($defPlayer) && HasStealth($attackID)) {
+        if (IsHeroAttackTarget() && CheckMarked($defPlayer) && HasStealth($attackID) && $cardID == $attackID) {
           AddLayer("TRIGGER", $mainPlayer, $characterID, $attackID, "MAINCHARHITEFFECT");
         }
         break;

--- a/CharacterAbilities.php
+++ b/CharacterAbilities.php
@@ -463,7 +463,7 @@ function MainCharacterEndTurnAbilities()
   }
 }
 
-function MainCharacterHitTrigger($cardID)
+function MainCharacterHitTrigger($cardID = "-")
 {
   global $CombatChain, $combatChainState, $CCS_WeaponIndex, $mainPlayer;
   $attackID = $CombatChain->AttackCard()->ID();
@@ -540,7 +540,7 @@ function MainCharacterHitTrigger($cardID)
         break;
       case "HNT001":
       case "HNT002":
-        if (IsHeroAttackTarget() && CheckMarked($defPlayer) && HasStealth($attackID) && $cardID == $attackID) {
+        if (IsHeroAttackTarget() && CheckMarked($defPlayer) && HasStealth($attackID) && ($cardID == "-" || $cardID == $attackID)) {
           AddLayer("TRIGGER", $mainPlayer, $characterID, $attackID, "MAINCHARHITEFFECT");
         }
         break;

--- a/CombatChain.php
+++ b/CombatChain.php
@@ -1,21 +1,13 @@
 <?php
 
-function ProcessHitEffect($cardID, $from = "-", $uniqueID = -1, $location = "-")
+function ProcessHitEffect($cardID, $from = "-", $uniqueID = -1)
 {
   global $CombatChain, $layers, $mainPlayer, $chainLinks;
   WriteLog("Processing hit effect for " . CardLink($cardID, $cardID));
   if (CardType($CombatChain->AttackCard()->ID()) == "AA" && SearchCurrentTurnEffects("OUT108", $mainPlayer, count($layers) <= LayerPieces())) return true;
   $cardID = ShiyanaCharacter($cardID);
 
-  if (DelimStringContains($location, "COMBATCHAINATTACKS", true) && TypeContains($cardID, "AA")) { //Kiss of Death added effects
-    $index = explode("-", $location)[1];
-    $activeEffects = explode(",", $chainLinks[$index][6]);
-    foreach ($activeEffects as $effect) {
-      AddEffectHitTrigger($effect);
-      AddOnHitTrigger($effect);
-    }
-  }
-
+  
   $set = CardSet($cardID);
   $class = CardClass($cardID);
   if ($set == "WTR") return WTRHitEffect($cardID);

--- a/CombatChain.php
+++ b/CombatChain.php
@@ -7,7 +7,6 @@ function ProcessHitEffect($cardID, $from = "-", $uniqueID = -1)
   if (CardType($CombatChain->AttackCard()->ID()) == "AA" && SearchCurrentTurnEffects("OUT108", $mainPlayer, count($layers) <= LayerPieces())) return true;
   $cardID = ShiyanaCharacter($cardID);
 
-  
   $set = CardSet($cardID);
   $class = CardClass($cardID);
   if ($set == "WTR") return WTRHitEffect($cardID);

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -1951,26 +1951,28 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
     case "ONHITEFFECT":
       $cardID = $lastResult;
       $location = $dqVars[2];
-      ProcessHitEffect($cardID, $parameter, location:$location);
+      AddOnHitTrigger($cardID);
+      if (DelimStringContains($location, "COMBATCHAINATTACKS", true) && TypeContains($cardID, "AA")) { //Kiss of Death added effects
+        $index = explode("-", $location)[1];
+        $activeEffects = explode(",", $chainLinks[$index][6]);
+        foreach ($activeEffects as $effect) {
+          AddEffectHitTrigger($effect);
+          AddOnHitTrigger($effect);
+        }
+      }
       MainCharacterHitTrigger($cardID);
-      ArsenalHitEffects();
+      ArsenalHitEffects(); // should be reworked to add a triggered-layer, but not urgent
       AuraHitEffects($cardID);
       ItemHitTrigger($cardID);
-      ProcessHitEffect($lastResult, $parameter);
-      //handling flick knives and mark
+      //mask of momentum
       $mainChar = &GetPlayerCharacter($mainPlayer);
       if(FindCharacterIndex($mainPlayer, "WTR079") != -1 && $mainChar[FindCharacterIndex($mainPlayer, "WTR079") + 5] > 0){
         --$mainChar[FindCharacterIndex($mainPlayer, "WTR079") + 5];
         AddCurrentTurnEffect("WTR079", $mainPlayer);
       }
+      //handling flick knives and mark
       if (CheckMarked($defPlayer)) {
-        if ($mainChar[0] == "HNT054" || $mainChar[0] == "HNT055" || $mainChar[0] == "HNT098" || $mainChar[0] == "HNT099") {
-          AddLayer("TRIGGER", $mainPlayer, $mainChar[0], $attackID, "MAINCHARHITEFFECT");
-        }
         RemoveMark($defPlayer);
-      }
-      if ($mainChar[0] == "HNT007") { //arakni, tarantula
-        AddLayer("TRIGGER", $mainPlayer, $mainChar[0], $defPlayer, "MAINCHARHITEFFECT");
       }
       return $parameter;
     case "AWAKEN":


### PR DESCRIPTION
Gist of this is that in flick onhit processing, instead of just immediately applying the effect, it now creates triggered-layers. This lets the triggers get put on the stack, then mark gets removed, then triggers resolved.