### PR TITLE
don't need to check if kiss is the active chain link

### DIFF
--- a/GameLogic.php
+++ b/GameLogic.php
@@ -2201,7 +2201,6 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
       return "";
     case "REMOVEINDICESIFACTIVECHAINLINK":
       $indices = explode(",", $lastResult);
-      WriteLog("HERE: $indices");
       $char = GetPlayerCharacter($player);
       for ($i = 0; $i < count($indices); $i++) {
         $option = explode("-", $indices[$i]);

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -2201,13 +2201,16 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
       return "";
     case "REMOVEINDICESIFACTIVECHAINLINK":
       $indices = explode(",", $lastResult);
+      WriteLog("HERE: $indices");
       $char = GetPlayerCharacter($player);
       for ($i = 0; $i < count($indices); $i++) {
         $option = explode("-", $indices[$i]);
-        if ($char[$option[1]] == $combatChain[0] && $char[$option[1] + 11] == $combatChain[8]) {
-          $lastResult = str_replace($indices[$i], "", $lastResult);
-          $lastResult = rtrim($lastResult, ",");
-          $lastResult = ltrim($lastResult, ",");
+        if ($option[0] == "MYCHAR") {
+          if ($char[$option[1]] == $combatChain[0] && $char[$option[1] + 11] == $combatChain[8]) {
+            $lastResult = str_replace($indices[$i], "", $lastResult);
+            $lastResult = rtrim($lastResult, ",");
+            $lastResult = ltrim($lastResult, ",");
+          }
         }
       }
       return $lastResult;


### PR DESCRIPTION
The way I search for kiss of death already skips the current chain link, so there's no need to remove it from the indices