### PR TITLE
add a chat message when pitching to retrieve

### DIFF
--- a/CardDictionaries/Hunted/HNTShared.php
+++ b/CardDictionaries/Hunted/HNTShared.php
@@ -1007,6 +1007,7 @@ function BubbleToTheSurface()
       AddDecisionQueue("YESNO", $player, "if_you_want_to_pay_a_resource_to_retrieve_a_$subtype");
       AddDecisionQueue("NOPASS", $player, "-", 1);
       AddDecisionQueue("PASSPARAMETER", $player, "1", 1);
+      AddDecisionQueue("WRITELOG", $player, "<b>Pitch cards to pay to retrieve</b>", 1);
       AddDecisionQueue("PAYRESOURCES", $player, "<-", 1);
       AddDecisionQueue("MULTIZONEINDICES", $player, "MYDISCARD:subtype=$subtype");
       AddDecisionQueue("SETDQCONTEXT", $player, "Choose a dagger to equip", 1);


### PR DESCRIPTION
players were confused by the window to pitch resources and thought that the card had failed to resolve