### PR TITLE
Uzuri fix and others

### DIFF
--- a/CardDictionaries/Hunted/HNTShared.php
+++ b/CardDictionaries/Hunted/HNTShared.php
@@ -539,7 +539,7 @@ function HNTPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
         if($character[$combatChainState[$CCS_WeaponIndex] + 1] == 1) $character[$combatChainState[$CCS_WeaponIndex] + 1] = 2;
       }
       elseif ($subtype) {
-        $ally = GetAllies($currentPlayer);
+        $ally = &GetAllies($currentPlayer);
         $allyIndex = SearchAlliesForUniqueID($combatChain[8], $currentPlayer);
         if($allyIndex != -1) {
           $ally[$allyIndex + 1] = 2;

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -2092,8 +2092,8 @@ function IsPlayRestricted($cardID, &$restriction, $from = "", $index = -1, $play
     case "OUT094":
       return !ArsenalHasFaceDownCard($player);
     case "OUT139":
-      if (!$CombatChain->HasCurrentLink()) return false;
-      if (!SearchCharacterAliveSubtype($player, "Dagger")) {
+      if (!$CombatChain->HasCurrentLink()) return true;
+      if (!SearchCharacterAliveSubtype($player, "Dagger") && SearchCombatChainAttacks($player, subtype:"Dagger") == "") {
         $restriction = "No dagger to throw";
         return true;
       }
@@ -2448,6 +2448,20 @@ function IsPlayRestricted($cardID, &$restriction, $from = "", $index = -1, $play
       break;
     case "HNT149":
       return GetClassState($currentPlayer, piece: $CS_NumActionsPlayed) > 0;
+    case "HNT173":
+      if (!$CombatChain->HasCurrentLink()) return true;
+      if (!SearchCharacterAliveSubtype($player, "Dagger") && SearchCombatChainAttacks($player, subtype:"Dagger") == "") {
+        $restriction = "No dagger to throw";
+        return true;
+      }
+      return false;
+    case "HNT175":
+      if (!$CombatChain->HasCurrentLink()) return true;
+      if (!SearchCharacterAliveSubtype($player, "Dagger") && SearchCombatChainAttacks($player, subtype:"Dagger") == "") {
+        $restriction = "No dagger to throw";
+        return true;
+      }
+      return false;
     case "HNT196":
       return $combatChainState[$CCS_NumUsedInReactions] == 0;
     case "HNT197":

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -2362,7 +2362,7 @@ function IsPlayRestricted($cardID, &$restriction, $from = "", $index = -1, $play
       return false;
     case "HNT014":
       if (!$CombatChain->HasCurrentLink()) return true;
-      if (HasStealth($CombatChain->AttackCard()->ID()) && CardType($CombatChain->AttackCard()->ID(), "AA")) return false;
+      if (HasStealth($CombatChain->AttackCard()->ID()) && DelimStringContains(CardType($CombatChain->AttackCard()->ID()), "AA", true)) return false;
       return true;
     case "HNT015":
       if (!$CombatChain->HasCurrentLink()) return true;

--- a/Constants.php
+++ b/Constants.php
@@ -493,6 +493,8 @@ function AttackReplaced($cardID, $player)
   $combatChain[5] = 0;//Reset Attack modifiers
   $combatChain[6] = 0;//Reset Defense modifiers
   $combatChain[7] = GetUniqueId($cardID, $player); //new unique id
+  $combatChain[9] = $cardID; //new original id
+  $combatChain[10] = "-"; // get rid of any layer continuous buffs
   CleanUpCombatEffects(true);
 }
 


### PR DESCRIPTION
1. Make dragon scaler flight path give allies another attack ($allies was being grabbed by value, not reference)
2. Fix uzuri swaps to reset original id and layer-continuous buffs
3. allow flicking when kiss of death is the only flickable dagger
4. fix a typo allowing mantle to target chelicera