### PR TITLE
Re-implementing blood runs deep as a respondable trigger

### DIFF
--- a/CardDictionaries/Hunted/HNTShared.php
+++ b/CardDictionaries/Hunted/HNTShared.php
@@ -390,8 +390,7 @@ function HNTPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
       RecurDagger($currentPlayer, 1);
       break;
     case "HNT057":
-      ThrowWeapon("Dagger", $cardID);
-      ThrowWeapon("Dagger", $cardID);
+      AddLayer("TRIGGER", $currentPlayer, "HNT057");
       break;
     case "HNT058":
       AddCurrentTurnEffect($cardID, $currentPlayer);

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -2771,6 +2771,10 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target = "-", $addition
       LoseHealth(1, $mainPlayer);
       if (!IsAllyAttacking()) TrapTriggered($parameter);
       break;
+    case "HNT057":
+      ThrowWeapon("Dagger", "HNT057");
+      ThrowWeapon("Dagger", "HNT057");
+      break;
     case "HNT073":
       $index = SearchAurasForUniqueID($uniqueID, $player);
       AddDecisionQueue("YESNO", $player, "if_you_want_to_destroy_".Cardlink("HNT073","HNT073")."_and_draw");


### PR DESCRIPTION
This affects the use case where cindra doesn't have daggers equips, plays blood runs deep to get a draconic chain link, then activates her ability in response.