### PR TITLE
always give mistblade buff to the next attacks, not current

### DIFF
--- a/CardDictionaries/PartTheMistveil/MSTShared.php
+++ b/CardDictionaries/PartTheMistveil/MSTShared.php
@@ -654,8 +654,7 @@ function MSTHitEffect($cardID, $from): void
   $discard = new Discard($defPlayer);
   switch ($cardID) {
     case "MST003":
-      if ($from != "OUT139" && $from != "OUT148" && $from != "OUT149" && $from != "OUT150") AddCurrentTurnEffect($cardID, $mainPlayer);
-      else AddCurrentTurnEffectNextAttack($cardID, $mainPlayer);
+      AddCurrentTurnEffectNextAttack($cardID, $mainPlayer);
       break;
     case "MST103":
       $count = count(GetDeck($defPlayer));


### PR DESCRIPTION
mistblade was buffing the current attack when flicked.
It's just easier to make it always apply to the next attack and then it doesn't matter if the hit comes from a flick or not