### PR TITLE
Dreacts during blocks

### DIFF
--- a/CardDictionaries/Hunted/HNTShared.php
+++ b/CardDictionaries/Hunted/HNTShared.php
@@ -1065,6 +1065,7 @@ function IsLayerContinuousBuff($cardID) {//tracks buffs that attach themselves t
   //for now only tracking dagger buffs, ideally we'd want to track all static buffs
   return match($cardID) {
     "OUT151" => true,
+    "HNT051-ATTACK" => true,
     "HNT179" => true,
     "HNT180" => true,
     "HNT181" => true,

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -1258,6 +1258,8 @@ function IsPlayable($cardID, $phase, $from, $index = -1, &$restriction = null, $
     $restriction = "Frozen";
     return false;
   }
+  if ($phase != "D" && DelimStringContains(CardType($cardID, $from), "DR") &&  GetResolvedAbilityName($cardID, $from) != "Ability") return false;
+  if ($phase != "A" && DelimStringContains(CardType($cardID, $from), "AR") &&  GetResolvedAbilityName($cardID, $from) != "Ability") return false;
   if ($phase == "D" && canBeAddedToChainDuringDR($cardID) && $combatChainState[$CCS_NumUsedInReactions] > 0) return true;
   if ($phase != "P" && $cardType == "DR" && IsAllyAttackTarget() && $currentPlayer != $mainPlayer) return false;
   if ($phase != "P" && $cardType == "AR" && IsAllyAttacking() && $currentPlayer == $mainPlayer) return false;

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -1502,7 +1502,6 @@ function PlayCard($cardID, $from, $dynCostResolved = -1, $index = -1, $uniqueID 
   if ($dynCostResolved == -1) {
     //CR 5.1.1 Play a Card (CR 2.0) - Layer Created
     if (SearchCurrentTurnEffects("HNT167", $currentPlayer) && TypeContains($cardID, "AA") && !SearchCurrentTurnEffects("HNT167-ATTACK", $currentPlayer) && GetResolvedAbilityName($cardID, $from) != "Ability") {
-      WriteLog("HERE adding attack effect");
       AddCurrentTurnEffect("HNT167-ATTACK", $currentPlayer);
     }
     if ($playingCard) {


### PR DESCRIPTION
Prevent dreacts and areacts outside their respective phases (and add 2 sides of the blade as a buff that can be tracked on kiss)