### PR TITLE
Damage step rework

### DIFF
--- a/CardDictionaries/Rosetta/ROSShared.php
+++ b/CardDictionaries/Rosetta/ROSShared.php
@@ -266,7 +266,7 @@ function ROSPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
         "ROS087" => 2
       };
       $options = SearchCombatChainLink($currentPlayer, "AA", minCost: $minCost);
-      if($options != "" && SearchLayersForPhase("FINALIZECHAINLINK") == -1) {
+      if($options != "") {
         $max = count(explode(",", $options));
         AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "COMBATCHAINLINK:type=AA;minCost=".$minCost);
         AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, "<-", 1);

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -2490,6 +2490,10 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target = "-", $addition
       AddDecisionQueue("PLAYAURA", $player, "HVY241-2", 1);
       AddDecisionQueue("WRITELOG", $player, "Player_" . $player . "_gained_2_".Cardlink("HVY241", "HVY241")."_tokens_from_" . CardLink("AKO005", "AKO005"), 1);
       break;
+    case "MST001":
+    case "MST002":
+      NuuStaticAbility($target);
+      break;
     case "MST027":
       AddDecisionQueue("YESNO", $player, "if_you_want_" . CardLink("MST027", "MST027") . "_to_gain_Ward_3");
       AddDecisionQueue("NOPASS", $player, "-");

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -2674,6 +2674,33 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target = "-", $addition
     case "ROS081":
       MZChooseAndBounce($mainPlayer, "THEIRAURAS:minCost=0;maxCost=1&THEIRAURAS:type=T&MYAURAS:minCost=0;maxCost=1&MYAURAS:type=T", may: true, context: "Choose an aura to return to its owner's hand");
       break;
+    case "ROS085":
+    case "ROS086":
+    case "ROS087":
+      $prevLink = $chainLinks[count($chainLinks) - 1];
+      $indices = array();
+      $index = -1;
+      for ($i = 0; $i < count($prevLink); $i += ChainLinksPieces()) {
+        if ($target == $prevLink[$i+7] && $prevLink[$i+2] == 1) {
+          array_push($indices, $i);
+        }
+      }
+      if (count($indices) == 1) {
+        $index = $indices[0];
+      }
+      else if (count($indices) > 1) { //if there are two copies of the same card on the link, assume the player chose their own card
+        // fix later
+        foreach ($indices as $i) {
+          if ($prevLink[$i + 1] == $player) $index = $i; 
+        }
+        if ($index == -1) $index = $indices[0];
+      }
+      if ($index != -1)
+      {
+        AddPlayerHand($target, $prevLink[$index + 1], "CC");
+        $chainLinks[count($chainLinks) - 1][$index + 2] = 0;
+      }
+      break;
     case "ROS114":
       PummelHit($otherPlayer);
       Draw($player);

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -2182,6 +2182,12 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target = "-", $addition
       AddCurrentTurnEffect($parameter, $mainPlayer);
       if (!IsAllyAttacking()) TrapTriggered($parameter);
       break;
+    case "OUT168":
+    case "OUT169":
+    case "OUT170":
+      WriteLog(CardLink($parameter, $parameter) . " creates a Bloodrot Pox from being blocked from hand.");
+      PlayAura($CID_BloodRotPox, $defPlayer, effectController:$mainPlayer);
+      break;
     case "OUT171":
       PlayAura($CID_BloodRotPox, $mainPlayer, effectController: $defPlayer);
       TrapTriggered($parameter);
@@ -2508,6 +2514,10 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target = "-", $addition
       $index = GetCombatChainIndex($parameter, $player);
       $chainCard = $CombatChain->Card($index);
       $chainCard->ModifyDefense(3);
+      break;
+    case "MST081":
+      Draw($player, effectSource:$parameter);
+      WriteLog(CardLink($parameter, $parameter) . " draw a card.");
       break;
     case "MST137":
     case "MST138":

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -1043,7 +1043,7 @@ function ChainLinkResolvedEffects()
   }
 }
 
-function ResolutionStepTriggers()
+function ResolutionStepEffectTriggers()
 {
   global $currentTurnEffects;
   for ($i = count($currentTurnEffects) - CurrentTurnEffectsPieces(); $i >= 0; $i -= CurrentTurnEffectsPieces()) {
@@ -1055,6 +1055,38 @@ function ResolutionStepTriggers()
         $player = $currentTurnEffects[$i + 1];
         AddLayer("TRIGGER", $player, $currentEffect[0], $currentEffect[1]);
         RemoveCurrentTurnEffect($i);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+function ResolutionStepCharacterTriggers()
+{
+  global $mainPlayer, $combatChain;
+  $character = &GetPlayerCharacter($mainPlayer);
+  for ($i = 0; $i < count($character); $i += CharacterPieces()) {
+    $charID = $character[$i];
+    switch ($charID) {
+      case "MST001":
+      case "MST002":
+        if (HasStealth($combatChain[0]) && $character[$i + 1] < 3) {
+          AddLayer("TRIGGER", $mainPlayer, $charID, $combatChain[0]);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+function ResolutionStepCombatChainTriggers()
+{
+  global $combatChain;
+  for ($i = 0; $i < count($combatChain); $i += CombatChainPieces()) {
+    switch ($combatChain[$i]) {
+      case "MST081":
         break;
       default:
         break;

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -1041,26 +1041,19 @@ function ChainLinkResolvedEffects()
   if (IsAllyAttacking() && isset($allies[$combatChainState[$CCS_WeaponIndex] + 2]) && $allies[$combatChainState[$CCS_WeaponIndex] + 2] <= 0) {
     DestroyAlly($mainPlayer, $combatChainState[$CCS_WeaponIndex]);
   }
+}
 
+function ResolutionStepTriggers()
+{
+  global $currentTurnEffects;
   for ($i = count($currentTurnEffects) - CurrentTurnEffectsPieces(); $i >= 0; $i -= CurrentTurnEffectsPieces()) {
     $currentEffect = explode("-", $currentTurnEffects[$i]);
     switch ($currentEffect[0]) {
       case "ROS085":
       case "ROS086":
       case "ROS087":
-        $index = GetCombatChainIndex($currentEffect[1], $currentTurnEffects[$i+1]);
-        if($index == -1) $index = GetCombatChainCardIDIndex($currentEffect[1]);
-        if($combatChainState[$CCS_GoesWhereAfterLinkResolves] != "-" && $index != -1)
-        {
-          if(substr($combatChain[$index+2], 0, 5) == "THEIR") AddPlayerHand($currentEffect[1], $combatChain[$index+1] == 1 ? 2 : 1, "CC");
-          else AddPlayerHand($currentEffect[1], $combatChain[$index+1], "CC");
-          $CombatChain->Remove($index);
-        }
-        else if($currentTurnEffects[$i+1] == $defPlayer && $index != -1) {
-          if(substr($combatChain[$index+2], 0, 5) == "THEIR") AddPlayerHand($currentEffect[1], $combatChain[$index+1] == 1 ? 2 : 1, "CC");
-          else AddPlayerHand($currentEffect[1], $combatChain[$index+1], "CC");
-          $CombatChain->Remove($index);
-        }
+        $player = $currentTurnEffects[$i + 1];
+        AddLayer("TRIGGER", $player, $currentEffect[0], $currentEffect[1]);
         RemoveCurrentTurnEffect($i);
         break;
       default:

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -1081,16 +1081,26 @@ function ResolutionStepCharacterTriggers()
   }
 }
 
-function ResolutionStepCombatChainTriggers()
+function ResolutionStepAttackTriggers()
 {
-  global $combatChain;
-  for ($i = 0; $i < count($combatChain); $i += CombatChainPieces()) {
-    switch ($combatChain[$i]) {
-      case "MST081":
+  global $mainPlayer, $defPlayer, $combatChain, $CID_BloodRotPox, $CS_Transcended;
+  switch ($combatChain[0]) {
+    case "OUT168":
+    case "OUT169":
+    case "OUT170":
+      for ($i = CombatChainPieces(); $i < count($combatChain); $i += CombatChainPieces()) {
+        if ($combatChain[$i + 1] != $defPlayer || $combatChain[$i + 2] != "HAND") continue;
+        AddLayer("TRIGGER", $mainPlayer, $combatChain[0]);
         break;
-      default:
-        break;
-    }
+      }
+      break;
+    case "MST081":
+      if (GetClassState($mainPlayer, $CS_Transcended) > 0) {
+        AddLayer("TRIGGER", $mainPlayer, $combatChain[0]);
+      }
+      break;
+    default:
+      break;
   }
 }
 

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -1169,6 +1169,7 @@ function FinalizeChainLink($chainClosed = false)
   array_push($chainLinkSummary, GetClassState($mainPlayer, $CS_ModalAbilityChoosen));
   
   ResolveWagers();
+  ResolutionStepTriggers();
   
 
   array_push($chainLinks, array());
@@ -1614,17 +1615,17 @@ function PlayCard($cardID, $from, $dynCostResolved = -1, $index = -1, $uniqueID 
   PlayerMacrosCardPlayed();
   //We've paid resources, now pay action points if applicable
   if ($playingCard) {
-    switch ($cardID) {
-      case "ROS085":
-      case "ROS086":
-      case "ROS087":         
-        if (SearchLayersForPhase("FINALIZECHAINLINK") != -1)
-        {
-          WriteLog("Playing " . CardLink($cardID, $cardID) . " is legal at this time, is legal at this time, but playing it after damage will have no effect.");
-        }
-      default:
-        break;
-    }
+    // switch ($cardID) {
+    //   case "ROS085":
+    //   case "ROS086":
+    //   case "ROS087":         
+    //     if (SearchLayersForPhase("FINALIZECHAINLINK") != -1)
+    //     {
+    //       WriteLog("Playing " . CardLink($cardID, $cardID) . " is legal at this time, is legal at this time, but playing it after damage will have no effect.");
+    //     }
+    //   default:
+    //     break;
+    // }
     if (ActionsThatDoArcaneDamage($cardID, $currentPlayer) || ActionsThatDoXArcaneDamage($cardID)) {
       if(!HasMeld($cardID) && (GetResolvedAbilityType($cardID) == "A" || GetResolvedAbilityType($cardID) == "") || HasMeld($cardID) && (GetClassState($currentPlayer, $CS_AdditionalCosts) != "Life" && GetClassState($currentPlayer, $CS_AdditionalCosts) != "Null"))
       {

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -999,27 +999,6 @@ function ChainLinkBeginResolutionEffects()
       }
     }
   }
-
-  switch ($combatChain[0]) {
-    case "OUT168":
-    case "OUT169":
-    case "OUT170":
-      for ($i = CombatChainPieces(); $i < count($combatChain); $i += CombatChainPieces()) {
-        if ($combatChain[$i + 1] != $defPlayer || $combatChain[$i + 2] != "HAND") continue;
-        WriteLog(CardLink($combatChain[0], $combatChain[0]) . " creates a Bloodrot Pox from being blocked from hand.");
-        PlayAura($CID_BloodRotPox, $defPlayer, effectController:$mainPlayer);
-        break;
-      }
-      break;
-    case "MST081":
-      if (GetClassState($mainPlayer, $CS_Transcended) > 0) {
-        Draw($mainPlayer);
-        WriteLog(CardLink($combatChain[0], $combatChain[0]) . " draw a card.");
-      }
-      break;
-    default:
-      break;
-  }
 }
 
 function ResolveChainLink()
@@ -1170,7 +1149,7 @@ function FinalizeChainLink($chainClosed = false)
   ResolveWagers();
   ResolutionStepEffectTriggers();
   ResolutionStepCharacterTriggers();
-  ResolutionStepCombatChainTriggers();
+  ResolutionStepAttackTriggers();
   
 
   array_push($chainLinks, array());


### PR DESCRIPTION
Here's my rework to apply the new resolution step trigger rules (https://fabtcg.com/en/articles/back-alley-oracle-16-combat-naming-tiebreakers/)

Effectively what this does is treat the current resolution step as the damage step and leaves all on-hit triggers happening there.
It now adds a couple function calls to FinalizeChainLink in NetworkingLibraries right after wagers (which funnily enough were already coded to work this way). Now when you leave what is currently labelled the resolution step, all these triggers will go on the stack and be respondable.

The cards I applied this change to are Electromagnetic Somersault, Nuu, Second Tenet of Chi Moon, and Virulent Touch.

To finalize this change, I think something should be done on the frontend to change the image for the "FINALIZECHAINLINK" layer to read "DAMAGE STEP" instead of "RESOLUTION STEP"
