### PR TITLE
Slippy rework

### DIFF
--- a/CharacterAbilities.php
+++ b/CharacterAbilities.php
@@ -1383,12 +1383,6 @@ function MainCharacterPlayCardAbilities($cardID, $from)
       case "DYN114":
         if (ContractType($cardID) != "") AddLayer("TRIGGER", $currentPlayer, $characterID);
         break;
-      case "OUT003":
-        if (HasStealth($cardID)) {
-          GiveAttackGoAgain();
-          $character[$i + 1] = 1;
-        }
-        break;
       case "OUT091":
       case "OUT092": //Riptide
         if ($from == "HAND" && GetResolvedAbilityName($cardID, "HAND") != "Ability") {
@@ -1418,12 +1412,6 @@ function MainCharacterPlayCardAbilities($cardID, $from)
           AddLayer("TRIGGER", $currentPlayer, $characterID);
         }
         break;
-      // case "HER130": case "HNT261":
-      //   if (HasStealth($cardID) && GetResolvedAbilityType($cardID, $from) != "I") {
-      //     GiveAttackGoAgain();
-      //     $character[$i + 1] = 1;
-      //   }
-      //   break;
       case "ROGUE017":
         if (CardType($cardID) == "AA") {
           $deck = &GetDeck($currentPlayer);
@@ -1463,12 +1451,6 @@ function MainCharacterPlayCardAbilities($cardID, $from)
   for ($j = 0; $j < count($otherPlayerCharacter); $j += CharacterPieces()) {
     if ($otherPlayerCharacter[$j + 1] != 2) continue;
     switch ($otherPlayerCharacter[$j]) {
-      // case "HER130": case "HNT261":
-      //   if (HasStealth($cardID) && GetResolvedAbilityType($cardID, $from) != "I") {
-      //     GiveAttackGoAgain();
-      //     $otherPlayerCharacter[$j + 1] = 1;
-      //   }
-      //   break;
       default:
         break;
     }

--- a/CharacterAbilities.php
+++ b/CharacterAbilities.php
@@ -1418,12 +1418,12 @@ function MainCharacterPlayCardAbilities($cardID, $from)
           AddLayer("TRIGGER", $currentPlayer, $characterID);
         }
         break;
-      case "HER130": case "HNT261":
-        if (HasStealth($cardID) && GetResolvedAbilityType($cardID, $from) != "I") {
-          GiveAttackGoAgain();
-          $character[$i + 1] = 1;
-        }
-        break;
+      // case "HER130": case "HNT261":
+      //   if (HasStealth($cardID) && GetResolvedAbilityType($cardID, $from) != "I") {
+      //     GiveAttackGoAgain();
+      //     $character[$i + 1] = 1;
+      //   }
+      //   break;
       case "ROGUE017":
         if (CardType($cardID) == "AA") {
           $deck = &GetDeck($currentPlayer);
@@ -1463,12 +1463,12 @@ function MainCharacterPlayCardAbilities($cardID, $from)
   for ($j = 0; $j < count($otherPlayerCharacter); $j += CharacterPieces()) {
     if ($otherPlayerCharacter[$j + 1] != 2) continue;
     switch ($otherPlayerCharacter[$j]) {
-      case "HER130": case "HNT261":
-        if (HasStealth($cardID) && GetResolvedAbilityType($cardID, $from) != "I") {
-          GiveAttackGoAgain();
-          $otherPlayerCharacter[$j + 1] = 1;
-        }
-        break;
+      // case "HER130": case "HNT261":
+      //   if (HasStealth($cardID) && GetResolvedAbilityType($cardID, $from) != "I") {
+      //     GiveAttackGoAgain();
+      //     $otherPlayerCharacter[$j + 1] = 1;
+      //   }
+      //   break;
       default:
         break;
     }

--- a/Constants.php
+++ b/Constants.php
@@ -348,6 +348,7 @@ $CS_TunicTicks = 91;
 $CS_OriginalHero = 92;
 $CS_NumTimesAttacked = 93; //number of attacks that reached the attack step, distinct from $CS_NumAttacks
 $CS_DamageDealtToOpponent = 94; //Damage dealt specifically to the opposing hero (for anaphylactic shock)
+$CS_NumStealthAttacks = 95; //for slippy
 
 //Combat Chain State (State for the current combat chain)
 $CCS_CurrentAttackGainedGoAgain = 0;
@@ -566,7 +567,7 @@ function ResetMainClassState()
   global $CS_NumVigorDestroyed, $CS_NumMightDestroyed, $CS_NumAgilityDestroyed, $CS_HaveIntimidated, $CS_ModalAbilityChoosen, $CS_NumSpectralShieldAttacks, $CS_NumInstantPlayed;
   global $CS_ActionsPlayed, $CS_NumEarthBanished, $CS_HealthGained, $CS_SkipAllRunechants, $CS_FealtyCreated, $CS_NumDraconicPlayed, $CS_NumSeismicSurgeDestroyed;
   global $CS_PowDamageDealt, $CS_NumTimesAttacked;
-  global $CS_TunicTicks, $CS_OriginalHero;
+  global $CS_TunicTicks, $CS_OriginalHero, $CS_NumStealthAttacks;
 
   $mainClassState[$CS_Num6PowDisc] = 0;
   $mainClassState[$CS_NumBoosted] = 0;
@@ -660,6 +661,7 @@ function ResetMainClassState()
   $mainClassState[$CS_PowDamageDealt] = 0;
   $mainClassState[$CS_TunicTicks] = 0;
   $mainClassState[$CS_NumTimesAttacked] = 0;
+  $mainClassState[$CS_NumStealthAttacks] = 0;
 }
 
 function ResetCardPlayed($cardID, $from="-")

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -1701,7 +1701,7 @@ function DoesAttackHaveGoAgain()
     if ($character[$i + 1] != 2) continue;
     $characterID = ShiyanaCharacter($character[$i]);
     switch ($characterID) {
-      case "HER130": case "HNT261":
+      case "OUT003": case "HER130": case "HNT261":
         if (HasStealth($attackID) && GetClassState($mainPlayer, piece: $CS_NumStealthAttacks) == 1) {
           return true;
         }

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -1658,7 +1658,7 @@ function DoesAttackHaveGoAgain()
   global $CS_NumAuras, $CS_ArcaneDamageTaken, $CS_AnotherWeaponGainedGoAgain, $CS_NumRedPlayed, $CS_NumNonAttackCards;
   global $CS_NumItemsDestroyed, $CCS_WeaponIndex, $CS_NumCharged, $CS_NumCardsDrawn, $CS_Transcended;
   global $CS_NumLightningPlayed, $CCS_NumInstantsPlayedByAttackingPlayer, $CS_ActionsPlayed, $CS_FealtyCreated;
-  global $chainLinks, $chainLinkSummary, $CCS_FlickedDamage;
+  global $chainLinks, $chainLinkSummary, $CCS_FlickedDamage, $defPlayer, $CS_NumStealthAttacks;
   $attackID = $CombatChain->AttackCard()->ID();
   $attackType = CardType($attackID);
   $attackSubtype = CardSubType($attackID);
@@ -1696,6 +1696,31 @@ function DoesAttackHaveGoAgain()
   if (IsWeaponGreaterThanTwiceBasePower() && SearchAuras("HNT118", $mainPlayer)) return true;
   //the last action in numActions is going to be the current chain link
   //so we want the second to last to be current funnel, and 3rd to last to be lightning
+  $character = &GetPlayerCharacter($mainPlayer);
+  for ($i = 0; $i < count($character); $i += CharacterPieces()) {
+    if ($character[$i + 1] != 2) continue;
+    $characterID = ShiyanaCharacter($character[$i]);
+    switch ($characterID) {
+      case "HER130": case "HNT261":
+        if (HasStealth($attackID) && GetClassState($mainPlayer, piece: $CS_NumStealthAttacks) == 1) {
+          return true;
+        }
+      default:
+        break;
+    }
+  }
+  $otherPlayerCharacter = &GetPlayerCharacter($defPlayer);
+  for ($j = 0; $j < count($otherPlayerCharacter); $j += CharacterPieces()) {
+    if ($otherPlayerCharacter[$j + 1] != 2) continue;
+    switch ($otherPlayerCharacter[$j]) {
+      case "HER130": case "HNT261":
+        if (HasStealth($attackID) && GetClassState($mainPlayer, $CS_NumStealthAttacks) == 1) {
+          return true;
+        }
+      default:
+        break;
+    }
+  }
   $mainPitch = &GetPitch($mainPlayer);
   switch ($attackID) {
     case "WTR078":

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -1478,7 +1478,7 @@ function PlayCard($cardID, $from, $dynCostResolved = -1, $index = -1, $uniqueID 
   global $decisionQueue, $CS_AbilityIndex, $CS_NumRedPlayed, $CS_PlayUniqueID, $CS_LayerPlayIndex, $CS_LastDynCost, $CS_NumCardsPlayed, $CS_NamesOfCardsPlayed, $CS_NumLightningPlayed;
   global $CS_PlayedAsInstant, $mainPlayer, $EffectContext, $combatChainState, $CCS_GoesWhereAfterLinkResolves, $CS_NumAttacks, $CCS_NumInstantsPlayedByAttackingPlayer;
   global $CCS_NextInstantBouncesAura, $CS_ActionsPlayed, $CS_AdditionalCosts, $CS_NumInstantPlayed;
-  global $CS_NumDraconicPlayed, $currentTurnEffects, $CS_TunicTicks, $CCS_NumUsedInReactions, $CCS_NumReactionPlayedActivated;
+  global $CS_NumDraconicPlayed, $currentTurnEffects, $CS_TunicTicks, $CCS_NumUsedInReactions, $CCS_NumReactionPlayedActivated, $CS_NumStealthAttacks;
 
   $otherPlayer = $currentPlayer == 1 ? 2 : 1;
   $resources = &GetResources($currentPlayer);
@@ -1694,6 +1694,9 @@ function PlayCard($cardID, $from, $dynCostResolved = -1, $index = -1, $uniqueID 
     if (TalentContains($cardID, "DRACONIC", $currentPlayer) && $from != "EQUIP" && $from != "PLAY" && GetResolvedAbilityName($cardID, $from) != "Ability") {
       IncrementClassState($currentPlayer, $CS_NumDraconicPlayed);
       SearchCurrentTurnEffects("HNT167", $currentPlayer, remove:true);
+    }
+    if (HasStealth($cardID) && GetResolvedAbilityName($cardID, $from) != "Ability") {
+      IncrementClassState($currentPlayer, piece: $CS_NumStealthAttacks);
     }
     if (DelimStringContains($playType, "A") || DelimStringContains($playType, "AA")) {
       if($from == "BANISH") $mod = GetBanishModifier($index);


### PR DESCRIPTION
Reworks slippy to be a continuous static effect, which will make go again fall off opponent's stealth cards if slippy uses mask of deceit