### PR TITLE
Feature/fabinsights exclude private fields

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -894,6 +894,7 @@ function SerializeDetailedGameResult($player, $DeckLink, $deckAfterSB, $gameID =
 		unset($deck["deckbuilderID"]);
 		unset($deck["cardResults"]);
 		unset($deck["character"]);
+		unset($deck["yourTime"]);
 		unset($deck["turnResults"]);
 		unset($deck["totalDamageThreatened"]);
 		unset($deck["totalDamageDealt"]);


### PR DESCRIPTION
## Summary
Modified FaBInsights integration to exclude private deck fields when players have stats disabled, while still sending game results.
     
## Changes
- Modified `SendFaBInsightsResults()` to accept flags for disabled stats per player
- Updated `SerializeDetailedGameResult()` to exclude private fields when stats disabled
- Private fields excluded: `deckbuilderID`, `cardResults`, `character`, `turnResults`, and all aggregate damage/statistics fields
- Anonymous game results (hero A won vs hero B) always sent to FaBInsights, but card, turn and game stats excluded based on player settings
- Added informative log messages matching Fabrary pattern (shows which player(s) disabled stats)
     
## Testing
- Tested with different combinations of player stat settings