### PR TITLE
feat: Add fabtcgmeta.com deck integration

### DIFF
--- a/APIs/JoinGame.php
+++ b/APIs/JoinGame.php
@@ -173,13 +173,8 @@ if ($decklink != "") {
     $apiLink = "https://api.fabdb.net/decks/" . $slug;
   } else if ($isFaBTCGMeta) {
     $parsedUrl = parse_url($decklink);
-    if (isset($parsedUrl['query'])) {
-      parse_str($parsedUrl['query'], $queryParams);
-      $deckId = $queryParams['deckName'] ?? $queryParams['deckId'] ?? '';
-    } else {
-      $decklinkArr = explode("/", $decklink);
-      $deckId = $decklinkArr[count($decklinkArr) - 1];
-    }
+    parse_str($parsedUrl['query'], $queryParams);
+    $deckId = $queryParams['deckName'] ?? $queryParams['deckId'] ?? '';
     $apiLink = "https://api.fabtcgmeta.com/api/talishar/deck/" . rawurlencode($deckId);
   } else if (str_contains($decklink, "fabrary")) {
     $headers = array(


### PR DESCRIPTION
Hey! 👋

This PR adds support for importing decks from [fabtcgmeta.com](https://fabtcgmeta.com) - a community site for Flesh & Blood that offers meta analysis, deck building, and tournament coverage.

## What it does
When a user pastes a fabtcgmeta deck URL, Talishar will now be able to fetch and load that deck just like it does for FaBDB and Fabrary.

## How it works
Follows the same pattern as the existing integrations - extracts the deck ID from the URL and constructs the API call server-side:

```php
$decklinkArr = explode("/", $decklink);
$deckId = $decklinkArr[count($decklinkArr) - 1];
$apiLink = "https://fabtcgmeta.com/api/talishar/deck/" . urlencode($deckId);
```

The API returns deck data in the same format Talishar expects (name, format, cards with identifiers).

Happy to make any changes if needed!