### PR TITLE
fix: name of constella flowslide in OMNCards.php

### DIFF
--- a/Classes/CardObjects/OMNCards.php
+++ b/Classes/CardObjects/OMNCards.php
@@ -6041,9 +6041,9 @@ class constella_contemplation_yellow extends Card {
   }
 }
 
-class constella_flowtide_yellow extends Card {
+class constella_flowslide_yellow extends Card {
   function __construct($controller) {
-    $this->cardID = "constella_flowtide_yellow";
+    $this->cardID = "constella_flowslide_yellow";
     $this->controller = $controller;
   }
   
@@ -6064,7 +6064,7 @@ class constella_flowtide_yellow extends Card {
   }
 
   function SpecialName() {
-    return "Constella Flowtide";
+    return "Constella Flowslide";
   }
 
   function SpecialPitch() {


### PR DESCRIPTION
Small typo with constella flowslide having been named constella flow(tide).

Looks like the naming convention with the FlowX cards are:

Illusionist: FlowTIDE
Runeblade: FlowSTRIDE
Wizard: FlowSLIDE

The error message confirms the cardID name on talishar when trying to submit a deck with constella flowslide:

The following cards are not yet supported: constella_flowslide_yellow 