### PR TITLE
Change ArcaneDamage return value from 4 to 3

### DIFF
--- a/Classes/CardObjects/OMNCards.php
+++ b/Classes/CardObjects/OMNCards.php
@@ -5364,7 +5364,7 @@ class lightning_overload_yellow extends Card {
   }
 
   function ArcaneDamage() {
-    return 4;
+    return 3;
   }
 }
 


### PR DESCRIPTION
Yellow lightning overload is printed with 3 arcane, probably just copy/paste error.