### PR TITLE
Standardize Cog tap/untap handling across Mechanologist cards

### DIFF
--- a/AI/PlayerMacros.php
+++ b/AI/PlayerMacros.php
@@ -245,6 +245,23 @@ function ProcessSpecificCardMacros()
         return true;
       }
     }
+    // Auto-resolve a cog tap/untap choice when every option is the same cog (card + steam counters + mod)
+    // identical cogs are interchangeable so don't make the player pick. Gated on the choice being a cog.
+    // Still prompts when the cogs differ (steam counters, a copper cog, a turn-stolen cog, etc.).
+    if (SubtypeContains(GetMZCard($currentPlayer, $firstChoice), "Cog", $currentPlayer)) {
+      $firstCog = MZIndexToObject($currentPlayer, $firstChoice);
+      if (is_object($firstCog)) {
+        $allSameCog = true;
+        for ($k = 1; $k < count($choices); ++$k) {
+          $cog = MZIndexToObject($currentPlayer, $choices[$k]);
+          if (!is_object($cog)
+            || $cog->CardID() != $firstCog->CardID()
+            || $cog->NumCounters() != $firstCog->NumCounters()
+            || $cog->Modalities() != $firstCog->Modalities()) { $allSameCog = false; break; }
+        }
+        if ($allSameCog) { ContinueDecisionQueue($firstChoice); return true; }
+      }
+    }
   }
   if ($turn[0] == "MAYCHOOSECARD" && ($EffectContext == "cindra_dracai_of_retribution" || $EffectContext == "cindra"))
   {

--- a/CardDictionaries/HighSeas/SEAShared.php
+++ b/CardDictionaries/HighSeas/SEAShared.php
@@ -633,7 +633,7 @@ function SEAPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
     case "spitfire":
       $inds = GetUntapped($currentPlayer, "MYITEMS", "subtype=Cog");
       if(empty($inds)) break;
-      AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Tap a cog to buff ".CardLink($cardID, $cardID));
+      AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "You may tap a cog to buff ".CardLink($cardID, $cardID)." (or pass)");
       AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, $inds, 1);
       AddDecisionQueue("MZTAP", $currentPlayer, "<-", 1);
       AddDecisionQueue("ADDCURRENTTURNEFFECT", $currentPlayer, $cardID, 1);

--- a/CardDictionaries/HighSeas/SEAShared.php
+++ b/CardDictionaries/HighSeas/SEAShared.php
@@ -746,7 +746,7 @@ function SEAPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
       if ($from != "PLAY") {
         $inds = GetUntapped($currentPlayer, "MYITEMS", "subtype=Cog");
         if(empty($inds)) break;
-        AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Tap a cog to gain overpower");
+        AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "You may tap a cog to gain overpower (or pass)");
         AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, $inds, 1);
         AddDecisionQueue("MZTAP", $currentPlayer, "<-", 1);
         AddDecisionQueue("ADDCURRENTTURNEFFECT", $currentPlayer, "jolly_bludger_yellow-OP", 1);

--- a/CharacterAbilities.php
+++ b/CharacterAbilities.php
@@ -1356,15 +1356,21 @@ function EquipPayAdditionalCosts($cardIndex)
       break;
     case "rust_belt":
       DestroyCharacter($currentPlayer, $cardIndex);
-      //for some reason DQs aren't working here, for now just automatically choose the first cog
       $inds = GetUntapped($currentPlayer, "MYITEMS", "subtype=Cog");
-      if($inds != "") Tap(explode(",", $inds)[0], $currentPlayer);
+      if ($inds != "") {
+        AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a Cog to tap for " . CardLink("rust_belt"));
+        AddDecisionQueue("CHOOSEMULTIZONE", $currentPlayer, $inds, 1);
+        AddDecisionQueue("MZTAP", $currentPlayer, "<-", 1);
+      }
       break;
     case "spitfire":
       Tap("MYCHAR-$cardIndex", $currentPlayer);
-      //for some reason DQs aren't working here, for now just automatically choose the first cog
       $inds = GetUntapped($currentPlayer, "MYITEMS", "subtype=Cog");
-      if($inds != "") Tap(explode(",", $inds)[0], $currentPlayer);
+      if ($inds != "") {
+        AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a Cog to tap for " . CardLink("spitfire"));
+        AddDecisionQueue("CHOOSEMULTIZONE", $currentPlayer, $inds, 1);
+        AddDecisionQueue("MZTAP", $currentPlayer, "<-", 1);
+      }
       break;
     case "cogwerx_blunderbuss":
       if (GetResolvedAbilityType($cardID) == "AA") {

--- a/Classes/CardObjects/SUPCards.php
+++ b/Classes/CardObjects/SUPCards.php
@@ -35,7 +35,11 @@ class backspin_thrust_red extends Card {
       }
       if ($from == "CC" || $from == "COMBATCHAINATTACKS") {
         $inds = GetTapped($this->controller, "MYITEMS", "subtype=Cog");
-        if($inds != "") Tap(explode(",", $inds)[0], $this->controller, 0);
+        if ($inds != "") {
+          AddDecisionQueue("SETDQCONTEXT", $this->controller, "Choose a Cog to untap for " . CardLink($this->cardID));
+          AddDecisionQueue("CHOOSEMULTIZONE", $this->controller, $inds, 1);
+          AddDecisionQueue("MZTAP", $this->controller, "0", 1);
+        }
         if ($from == "COMBATCHAINATTACKS") ++$chainLinks[$i][9];
         else ++$combatChain[$i + 11];
       }


### PR DESCRIPTION
Several Mechanologist cards auto-selected the *first* available Cog when a Cog had to be tapped or untapped, instead of letting the player choose. Most other Cog cards in the engine (`cogwerx_blunderbuss`, `cog_in_the_machine`, `tighten_the_screws`, ...) already route this through the decision queue, so this just brings the stragglers in line - every Mechanologist cog interaction now behaves the same way for the player. A couple of *optional* Cog taps were also worded as if they were mandatory.

This doesn't change any outcome today, but it keeps the behavior consistent across cards, and if a future card ever cares which Cog is tapped or untapped, the engine will already handle the choice correctly instead of always grabbing the first one.

## Changes
- **Spitfire** & **Rust Belt** - choose which Cog to tap to pay their cost (was auto-first)
- **Backspin Thrust** - choose which Cog to untap for its cost (was auto-first)
- **Spitfire** buff & **Jolly Bludger** - optional Cog tap now reads "You may ... (or pass)" instead of sounding mandatory

## Testing
Verified locally (Docker): the cost now prompts for a Cog, the chosen one is the one affected, single-Cog auto-resolves with no prompt, and no regression.