### PR TITLE
Fix Overcrowded not counting token copy auras

### DIFF
--- a/CardLogic.php
+++ b/CardLogic.php
@@ -4632,7 +4632,7 @@ function ProcessAttackTrigger($cardID, $player, $target="-", $uniqueID = -1)
         $auraCount = count($auras);
         for($i = 0; $i < $auraCount; $i += $auraPieces) {
           $name = NameOverride($auras[$i], $player);
-          if (TypeContains($auras[$i], "T") && !isset($uniqueAurasSet[$name])) {
+          if ((TypeContains($auras[$i], "T") || $auras[$i + 4] == 1) && !isset($uniqueAurasSet[$name])) {
             $uniqueAuras[] = $name;
             $uniqueAurasSet[$name] = true;
           }


### PR DESCRIPTION
Overcrowded wasn't counting token copies of non-token auras (e.g. a Shimmers of Silver token copy made by Miraging Metamorph) — the token check only looked at the printed card type. Now also checks the runtime `isToken` flag, matching `renounce_grandeur_red`.

Repro: bug report game 1376975 — Overcrowded blocked for 5 with a token Shimmers of Silver in play, should be 6. Verified fixed locally.
