### PR TITLE
Show zone labels in multizone popups when choices span multiple zones

### DIFF
--- a/BuildPlayerInputPopup.php
+++ b/BuildPlayerInputPopup.php
@@ -551,8 +551,6 @@ function BuildPlayerInputPopupFull($playerID, $turnPhase, $turn, $gameName) {
         $subtitles = "";
         $source = [];
         $optionsCount = count($options);
-        // Zone labels disambiguate choices that span multiple zones (e.g. Lighten
-        // the Load: destroy an item in play or discard the same card from hand).
         $zoneCategories = [];
         for ($j = 0; $j < $optionsCount; ++$j) {
           $optParts = explode("-", $options[$j], 3);
@@ -880,8 +878,6 @@ function BuildPlayerInputPopupFull($playerID, $turnPhase, $turn, $gameName) {
           if($option0 == "MYDECK" && $option[1] == "0" && $isMayChooseMultizone && $singleMyDeckInTurnData) {
             $card = $MyCardBack;
           }
-          // Own hand cards are face-up to their owner, so labeling every other
-          // zone disambiguates by elimination without labeling the whole hand.
           if ($showZoneLabels && $label == "" && $option0 != "MYHAND") {
             $label = MZZoneCategory($option0, intval($option[1] ?? 0));
           }

--- a/BuildPlayerInputPopup.php
+++ b/BuildPlayerInputPopup.php
@@ -36,6 +36,43 @@ if (!function_exists('GetCardEffectLabel')) {
   }
 }
 
+// Maps a multizone option's zone prefix to the zone word shown on popup cards
+// (and used to decide whether a popup's choices span multiple zones).
+// Returns "" for non-zone keys, which are excluded from that decision.
+function MZZoneCategory($zoneKey, $index) {
+  switch ($zoneKey) {
+    case "MYHAND": case "THEIRHAND":
+      return "Hand";
+    case "MYITEMS": case "THEIRITEMS":
+    case "MYAURAS": case "THEIRAURAS":
+    case "MYALLY": case "THEIRALLY":
+    case "MYPERM": case "THEIRPERM":
+    case "LANDMARK":
+      return "In Play";
+    case "MYCHAR": case "THEIRCHAR":
+      // Index 0 is the hero: never labeled and never opens the gate — there is
+      // only ever one hero and it's visually unmistakable.
+      return $index == 0 ? "" : "Equipment";
+    case "MYARS": case "THEIRARS":
+    case "MYARSENAL": case "THEIRARSENAL":
+      return "Arsenal";
+    case "MYDISCARD": case "THEIRDISCARD":
+      return "Graveyard";
+    case "MYDECK": case "THEIRDECK":
+      return "Deck";
+    case "MYBANISH": case "THEIRBANISH":
+      return "Banish";
+    case "MYPITCH": case "THEIRPITCH":
+      return "Pitch";
+    case "MYSOUL": case "THEIRSOUL":
+      return "Soul";
+    case "CC": case "COMBATCHAINLINK": case "COMBATCHAINATTACKS": case "PASTCHAINLINK":
+      return "Chain";
+    default:
+      return "";
+  }
+}
+
 function BuildPlayerInputPopupFull($playerID, $turnPhase, $turn, $gameName) {
   global $myHand, $myPitch, $myDeck, $theirDeck, $myDiscard, $theirDiscard;
   global $myBanish, $theirBanish, $myArsenal, $theirArsenal;
@@ -519,20 +556,25 @@ function BuildPlayerInputPopupFull($playerID, $turnPhase, $turn, $gameName) {
         $subtitles = "";
         $source = [];
         $optionsCount = count($options);
+        // Zone labels disambiguate choices that span multiple zones (e.g. Lighten
+        // the Load: destroy an item in play or discard the same card from hand).
+        $zoneCategories = [];
+        for ($j = 0; $j < $optionsCount; ++$j) {
+          $optParts = explode("-", $options[$j], 3);
+          $category = MZZoneCategory($optParts[0], intval($optParts[1] ?? 0));
+          if ($category != "") $zoneCategories[$category] = true;
+        }
+        $showZoneLabels = count($zoneCategories) >= 2;
         static $attackingPermanentsSet = ['THEIRALLY' => true, 'THEIRAURAS' => true, 'MYALLY' => true, 'MYAURAS' => true];
-        $combatChainCount = count($combatChain);
         $layerCheckCount = count($layers);
         $turnDataStartsWithMyDeck = (substr($turnData, 0, 6) === "MYDECK");
         $singleMyDeckInTurnData = (substr_count($turnData, "MYDECK") == 1);
         $hasCombatChainLink = $CombatChain->HasCurrentLink();
         $weaponIndexValue = intval($combatChainState[$CCS_WeaponIndex]);
         $otherIsMain = ($otherPlayer == $mainPlayer);
-        $combatChainPieces = CombatChainPieces();
         $layerPieces = LayerPieces();
         $layersActive = ($layerCheckCount > 0 && $layers[0] != "");
         $isMayChooseMultizone = ($turnPhase === "MAYCHOOSEMULTIZONE");
-        $combatChainFirst = $combatChainCount > 0 ? $combatChain[0] : null;
-        $combatChainLast = $combatChainCount > 0 ? $combatChain[$combatChainCount - $combatChainPieces] : null;
         for ($i = 0; $i < $optionsCount; ++$i) {
           $option = explode("-", $options[$i], 3);
           $option0 = $option[0]; // cache zone key — accessed 30+ times per iteration
@@ -723,41 +765,6 @@ function BuildPlayerInputPopupFull($playerID, $turnPhase, $turn, $gameName) {
             }
           }
 
-          //Bonds of Agony - add indication for hand, graveyard and deck
-          if ($isMayChooseMultizone && $combatChainCount > 0) {
-            if ($combatChainFirst == "bonds_of_agony_blue") {
-              switch ($option0) {
-                  case "THEIRHAND":
-                      $label = "Hand";
-                      break;
-                  case "THEIRDECK":
-                      $label = "Deck";
-                      break;
-                  case "THEIRDISCARD":
-                      $label = "Graveyard";
-                      break;
-              }  
-            }
-            if ($combatChainLast == "hunter_or_hunted_blue") {
-              switch ($option0) {
-                  case "THEIRHAND":
-                      $label = "Hand";
-                      break;
-                  case "THEIRDECK":
-                      $label = "Deck";
-                      break;
-                  case "THEIRDISCARD":
-                      $label = "Graveyard";
-                      break;
-                  case "THEIRARSENAL":
-                      $label = "Arsenal";
-                      break;
-              }  
-            }
-          }
-
-          //Add indication for Crown of Providence if you have the same card in hand and in the arsenal.
-          if ($option0 == "MYARS") $label = "Arsenal";
           //Add indication for past chain links
           if ($option0 == "PASTCHAINLINK") $label = "Chain link " . ($option[2] + 1);
           //Add indication for Attacking Mechanoid
@@ -878,10 +885,15 @@ function BuildPlayerInputPopupFull($playerID, $turnPhase, $turn, $gameName) {
           if($option0 == "MYDECK" && $option[1] == "0" && $isMayChooseMultizone && $singleMyDeckInTurnData) {
             $card = $MyCardBack;
           }
+          // Own hand cards are face-up to their owner, so labeling every other
+          // zone disambiguates by elimination without labeling the whole hand.
+          if ($showZoneLabels && $label == "" && $option0 != "MYHAND") {
+            $label = MZZoneCategory($option0, intval($option[1] ?? 0));
+          }
           if ($maxCount < 2)
             $cardsMultiZone[] = JSONRenderedCard($card, action: 16, overlay: $overlay, borderColor: $borderColor, counters: $counters, actionDataOverride: $options[$i], lifeCounters: $lifeCounters, defCounters: $enduranceCounters, powerCounters: $powerCounters, controller: $borderColor, label: $label, steamCounters: $steamCounters, tapped: $tapped, isOpponent: $isTheirPrefix, holoCounters: $holoCounters);
           else
-            $cardsMultiZone[] = JSONRenderedCard($card, overlay: $overlay, actionDataOverride: $i - $countOffset);
+            $cardsMultiZone[] = JSONRenderedCard($card, overlay: $overlay, actionDataOverride: $i - $countOffset, label: $label);
         }
         if ($maxCount >= 2) {
           $formOptions = new stdClass();

--- a/BuildPlayerInputPopup.php
+++ b/BuildPlayerInputPopup.php
@@ -36,9 +36,6 @@ if (!function_exists('GetCardEffectLabel')) {
   }
 }
 
-// Maps a multizone option's zone prefix to the zone word shown on popup cards
-// (and used to decide whether a popup's choices span multiple zones).
-// Returns "" for non-zone keys, which are excluded from that decision.
 function MZZoneCategory($zoneKey, $index) {
   switch ($zoneKey) {
     case "MYHAND": case "THEIRHAND":
@@ -50,8 +47,6 @@ function MZZoneCategory($zoneKey, $index) {
     case "LANDMARK":
       return "In Play";
     case "MYCHAR": case "THEIRCHAR":
-      // Index 0 is the hero: never labeled and never opens the gate — there is
-      // only ever one hero and it's visually unmistakable.
       return $index == 0 ? "" : "Equipment";
     case "MYARS": case "THEIRARS":
     case "MYARSENAL": case "THEIRARSENAL":
@@ -67,7 +62,7 @@ function MZZoneCategory($zoneKey, $index) {
     case "MYSOUL": case "THEIRSOUL":
       return "Soul";
     case "CC": case "COMBATCHAINLINK": case "COMBATCHAINATTACKS": case "PASTCHAINLINK":
-      return "Chain";
+      return "Combat Chain";
     default:
       return "";
   }


### PR DESCRIPTION
## What

Card-choice popups (`CHOOSEMULTIZONE`/`MAYCHOOSEMULTIZONE`) now label each card with its zone ("In Play", "Hand", "Deck", "Graveyard", "Arsenal", ...) whenever the options span more than one zone, so identical-looking cards from different zones can be told apart.

Motivating case: Lighten the Load with a Copper Cog in play and another in hand showed two identical cogs with no way to tell which one you were destroying off the board vs discarding from hand.

## Behavior

- Labels appear only when a popup's choices span 2+ zone categories; single-zone popups are unchanged.
- Your own hand cards are never labeled (they're face-up to you — labeling the other zones disambiguates by elimination). Opponent hand cards do get "Hand", since they render as card backs.
- The hero is never labeled and doesn't trigger labeling (only one hero ever exists), so hero + ally targeting popups stay exactly as they are today.
- Existing status labels ("Attacking", "Token Copy", "Targeted", etc.) always take precedence over the zone label.
- Multi-select (checkbox) popups now carry labels too — they previously dropped all labels.

## Refactor

Replaces three per-card label hacks with the one generic mechanism: Bonds of Agony (blue), Hunter or Hunted (blue), and Crown of Providence, plus their now-unused local variables. Mixed-zone popups produce identical labels to before (verified in-game, see below). Two intentional notes:

- The old hacks also fired when every option sat in a single zone (e.g. all remaining copies in deck, or an arsenal-only popup); those popups now show no labels, since there is nothing to disambiguate and the popup caption already states the zone.
- The old Bonds/Hunter hacks applied their labels to *any* `MAYCHOOSEMULTIZONE` popup while the card sat on the chain, not just their own popup — the generic path doesn't have that quirk.

## Testing (local stack, real games)

- Lighten the Load with cogs in play and in hand: only the in-play copies show "In Play"; hand copies bare
- Same popup with items only (no hand cards): no labels
- Hunter or Hunted (blue): "Hand"/"Deck" pills on the banish popup card backs, matching current behavior
- Crown of Providence: "Arsenal" pill preserved on the arsenal card, hand cards bare
- Steam counters and other popup counters render unchanged
