### PR TITLE
Fix Spitfire's +1 cog prompt being skipped after declining a wager

### DIFF
--- a/CardDictionaries/HighSeas/SEAShared.php
+++ b/CardDictionaries/HighSeas/SEAShared.php
@@ -655,7 +655,7 @@ function SEAPlayAbility($cardID, $from, $resourcesPaid, $target = "-", $addition
       $inds = GetUntapped($currentPlayer, "MYITEMS", "subtype=Cog");
       if(empty($inds)) break;
       AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "You may tap a cog to buff ".CardLink($cardID, $cardID)." (or pass)");
-      AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, $inds, 1);
+      AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, $inds);
       AddDecisionQueue("MZTAP", $currentPlayer, "<-", 1);
       AddDecisionQueue("ADDCURRENTTURNEFFECT", $currentPlayer, $cardID, 1);
       break;


### PR DESCRIPTION
User report: Money Where Ya Mouth Is stops Spitfire from gaining the +1 from its own ability.

Declining the wager leaves the decision queue in a PASS state, and Spitfire's `MAYCHOOSEMULTIZONE` had `subsequent = 1`, so the cog prompt got skipped. Removed the flag so the prompt always shows. Verified locally.