### PR TITLE
Add per turn logs to fabinsights payload and track arcane damage.

### DIFF
--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -800,6 +800,8 @@ function FinalizeDamage($player, $damage, $damageThreatened, $type, $source, $pl
   if ($playerSource != $player) LogDamageStats($player, $damageThreatened, $damage);
   else LogLifeLossStats($player, $damage); //Self inflicting damage e.g. Flick Knives, Hexagore, etc.
   if ($type == "ARCANE" && $player != $playerSource) IncrementClassState($playerSource, $CS_ArcaneDamageDealtToOpponent, $damage);
+  //I believe IncrementClassState resets every turn and is used to activate effects that check if arcane was dealt that turn so I added line below
+  if ($type == "ARCANE" && $player != $playerSource) LogArcaneDamageStats($player, $damage);
   WriteLog("Player $player took $damage damage");
   PlayerLoseHealth($damage, $player);
   // mark once per damage instance effects as usable again

--- a/Libraries/StatFunctions.php
+++ b/Libraries/StatFunctions.php
@@ -150,6 +150,21 @@ function LogDamageStats($player, $damageThreatened, $damageDealt)
   $damagerStats[$baseIndex + $TurnStats_DamageDealt] += $damageDealt;
 }
 
+// Called on FinalizeDamage() and $damageDealt is $type == ARCANE only tracks damage dealt to opposing players
+function LogArcaneDamageStats($player, $damageDealt)
+{
+  global $p1ArcaneDamageDealt, $p2ArcaneDamageDealt;
+  $playerSource = $player == 1 ? 2 : 1;
+  $turnIndex = GetStatTurnIndex($playerSource);
+  if ($playerSource == 1) {
+    if (!isset($p1ArcaneDamageDealt[$turnIndex])) $p1ArcaneDamageDealt[$turnIndex] = 0;
+    $p1ArcaneDamageDealt[$turnIndex] += $damageDealt;
+  } else {
+    if (!isset($p2ArcaneDamageDealt[$turnIndex])) $p2ArcaneDamageDealt[$turnIndex] = 0;
+    $p2ArcaneDamageDealt[$turnIndex] += $damageDealt;
+  }
+}
+
 function LogLifeGainedStats($player, $healthGained)
 {
   global $TurnStats_LifeGained;

--- a/ParseGamestate.php
+++ b/ParseGamestate.php
@@ -31,7 +31,7 @@ function ParseGamestate()
   global $p1ClassState, $p1CharacterEffects, $p1Soul, $p1CardStats, $p1TurnStats, $p1Allies, $p1Permanents, $p1Settings;
   global $p2Hand, $p2Deck, $p2CharEquip, $p2Resources, $p2Arsenal, $p2Items, $p2Auras, $p2Discard, $p2Pitch, $p2Banish;
   global $p2ClassState, $p2CharacterEffects, $p2Soul, $p2CardStats, $p2TurnStats, $p2Allies, $p2Permanents, $p2Settings;
-  global $p1CardTurnLog, $p2CardTurnLog, $p1LifeHistory, $p2LifeHistory;
+  global $p1CardTurnLog, $p2CardTurnLog, $p1LifeHistory, $p2LifeHistory, $p1ArcaneDamageDealt, $p2ArcaneDamageDealt;
   global $landmarks, $winner, $firstPlayer, $currentPlayer, $currentTurn, $turn, $actionPoints, $combatChain, $combatChainState;
   global $currentTurnEffects, $currentTurnEffectsFromCombat, $nextTurnEffects, $decisionQueue, $dqVars, $dqState;
   global $layers, $layerPriority, $mainPlayer, $defPlayer, $lastPlayed, $chainLinks, $chainLinkSummary, $p1Key, $p2Key;
@@ -153,6 +153,8 @@ function ParseGamestate()
   $attackQueue = GetStringArray($gamestateContent[79+$numChainLinks] ?? "");
   $p1LifeHistory = isset($gamestateContent[80+$numChainLinks]) ? json_decode(trim($gamestateContent[80+$numChainLinks]), true) ?? [] : [];
   $p2LifeHistory = isset($gamestateContent[81+$numChainLinks]) ? json_decode(trim($gamestateContent[81+$numChainLinks]), true) ?? [] : [];
+  $p1ArcaneDamageDealt = isset($gamestateContent[82+$numChainLinks]) ? json_decode(trim($gamestateContent[82+$numChainLinks]), true) ?? [] : [];
+  $p2ArcaneDamageDealt = isset($gamestateContent[83+$numChainLinks]) ? json_decode(trim($gamestateContent[83+$numChainLinks]), true) ?? [] : [];
 
   BuildMyGamestate($playerID);
 }

--- a/WriteGamestate.php
+++ b/WriteGamestate.php
@@ -118,7 +118,9 @@ array_push($gamestateLines,
   json_encode($p2CardTurnLog),
   implode(" ", is_array($attackQueue ?? null) ? $attackQueue : []),
   json_encode($p1LifeHistory ?? []),
-  json_encode($p2LifeHistory ?? [])
+  json_encode($p2LifeHistory ?? []),
+  json_encode($p1ArcaneDamageDealt ?? []),
+  json_encode($p2ArcaneDamageDealt ?? [])
 );
 
 $gamestateContent = implode("\r\n", $gamestateLines) . "\r\n";

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -627,6 +627,8 @@ function PrepareFaBInsightsRequest($gameID, $detailedResult1Json, $detailedResul
 	$payloadArr['player2Name'] = $hashedP2Name;
 	$payloadArr['deck1'] = json_decode($detailedResult1Json);
 	$payloadArr['deck2'] = json_decode($detailedResult2Json);
+	if (isset($payloadArr['deck1']->turnResults)) $payloadArr['deck1']->turnLog = GetCardTurnLog(1);
+	if (isset($payloadArr['deck2']->turnResults)) $payloadArr['deck2']->turnLog = GetCardTurnLog(2);
 	$payloadArr["format"] = $format;
 	$payloadArr['gameGUID'] = $gameGUID;
 	$payloadArr['conceded'] = $conceded;
@@ -720,8 +722,11 @@ function PopulateTurnStatsAndAggregates(&$deck, &$turnStats, &$otherPlayerTurnSt
 	global $TurnStats_ResourcesUsed, $TurnStats_CardsLeft, $TurnStats_ResourcesLeft, $TurnStats_LifeGained;
 	global $TurnStats_LifeLost, $TurnStats_DamagePrevented, $TurnStats_CardsDiscarded, $p1TotalTime, $p2TotalTime;
 	global $p1LifeHistory, $p2LifeHistory;
+	global $p1ArcaneDamageDealt, $p2ArcaneDamageDealt;
 	$lifeHistory = $player == 1 ? $p1LifeHistory : $p2LifeHistory;
 	$opponentLifeHistory = $player == 1 ? $p2LifeHistory : $p1LifeHistory;
+	$arcaneDealt = ($player == 1 ? $p1ArcaneDamageDealt : $p2ArcaneDamageDealt) ?? [];
+	$arcaneTaken = ($player == 1 ? $p2ArcaneDamageDealt : $p1ArcaneDamageDealt) ?? [];
 
 	$countTurnStats = count($turnStats);
 	$tsp = TurnStatPieces();
@@ -776,6 +781,8 @@ function PopulateTurnStatsAndAggregates(&$deck, &$turnStats, &$otherPlayerTurnSt
 		$entry["damageBlocked"] = $damageBlocked;
 		$entry["damagePrevented"] = $damagePrevented;
 		$entry["damageTaken"] = $damageTaken;
+		$entry["arcaneDamageDealt"] = isset($arcaneDealt[$turnNo]) ? (int)$arcaneDealt[$turnNo] : 0;
+		$entry["arcaneDamageTaken"] = isset($arcaneTaken[$turnNo]) ? (int)$arcaneTaken[$turnNo] : 0;
 		$entry["lifeGained"] = $lifeGained;
 		$entry["lifeLost"] = $lifeLost;
 		$entry["lifeAtTurnEnd"] = isset($lifeHistory[$turnNo]) ? (int)$lifeHistory[$turnNo] : null;


### PR DESCRIPTION
1. turnLog: included the the per-turn card play log ([turn, cardID, type]) sent to FaBBazaar into FaBInsights payload, only if data is enabled by the user.
2. arcane damage: tracks arcane damage dealt/taken per turn. Logged in FinalizeDamage when the damage type is arcane