### PR TITLE
feat(telemetry): report starting hero

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1134,6 +1134,53 @@ function SerializeGameResult($player, $DeckLink, $deckAfterSB, $gameID = "", $op
 	return json_encode($deck);
 }
 
+function ExtractStartingHeroFromCharacterLine($character)
+{
+	$cards = preg_split('/\s+/', trim($character), -1, PREG_SPLIT_NO_EMPTY);
+	return count($cards) > 0 ? $cards[0] : "";
+}
+
+function AddStartingHeroToDetailedResult(&$deck, $character)
+{
+	$startingHero = ExtractStartingHeroFromCharacterLine($character);
+	if ($startingHero != "") $deck["startingHero"] = $startingHero;
+}
+
+function ExcludePrivateDetailedGameResultFields(&$deck)
+{
+	unset($deck["deckbuilderID"]);
+	unset($deck["cardResults"]);
+	unset($deck["character"]);
+	unset($deck["yourTime"]);
+	unset($deck["turnResults"]);
+	unset($deck["totalDamageThreatened"]);
+	unset($deck["totalDamageDealt"]);
+	unset($deck["totalLifeGained"]);
+	unset($deck["totalDamageBlocked"]);
+	unset($deck["totalDamagePrevented"]);
+	unset($deck["totalLifeLost"]);
+	unset($deck["averageDamageThreatenedPerTurn"]);
+	unset($deck["averageDamageDealtPerTurn"]);
+	unset($deck["averageDamageThreatenedPerCard"]);
+	unset($deck["averageResourcesUsedPerTurn"]);
+	unset($deck["averageCardsLeftOverPerTurn"]);
+	unset($deck["averageCombatValuePerTurn"]);
+	unset($deck["averageValuePerTurn"]);
+	unset($deck["totalDamageThreatened_NoLast"]);
+	unset($deck["totalDamageDealt_NoLast"]);
+	unset($deck["totalLifeGained_NoLast"]);
+	unset($deck["totalDamageBlocked_NoLast"]);
+	unset($deck["totalDamagePrevented_NoLast"]);
+	unset($deck["totalLifeLost_NoLast"]);
+	unset($deck["averageDamageThreatenedPerTurn_NoLast"]);
+	unset($deck["averageDamageDealtPerTurn_NoLast"]);
+	unset($deck["averageDamageThreatenedPerCard_NoLast"]);
+	unset($deck["averageResourcesUsedPerTurn_NoLast"]);
+	unset($deck["averageCardsLeftOverPerTurn_NoLast"]);
+	unset($deck["averageCombatValuePerTurn_NoLast"]);
+	unset($deck["averageValuePerTurn_NoLast"]);
+}
+
 function SerializeDetailedGameResult($player, $DeckLink, $deckAfterSB, $gameID = "", $opposingHero = "", $gameName = "", $deckbuilderID = "", $playerHero = "", $excludePrivateFields = false)
 {
 	global $winner, $currentTurn, $CardStats_TimesPlayed, $CardStats_TimesBlocked, $CardStats_TimesPitched, $CardStats_TimesHit, $CardStats_TimesCharged, $firstPlayer;
@@ -1148,6 +1195,7 @@ function SerializeDetailedGameResult($player, $DeckLink, $deckAfterSB, $gameID =
 	$character = $deckAfterSB[0];
 	$deckAfterSB = $deckAfterSB[1];
 	$deck = [];
+	AddStartingHeroToDetailedResult($deck, $character);
 	if($gameID != "") $deck["gameId"] = $gameID;
 	if($gameName != "") $deck["gameName"] = $gameName;
 	$deck["deckId"] = $DeckLink;
@@ -1253,37 +1301,7 @@ function SerializeDetailedGameResult($player, $DeckLink, $deckAfterSB, $gameID =
 
 	// Exclude private fields if stats are disabled
 	if ($excludePrivateFields) {
-		unset($deck["deckbuilderID"]);
-		unset($deck["cardResults"]);
-		unset($deck["character"]);
-		unset($deck["yourTime"]);
-		unset($deck["turnResults"]);
-		unset($deck["totalDamageThreatened"]);
-		unset($deck["totalDamageDealt"]);
-		unset($deck["totalLifeGained"]);
-		unset($deck["totalDamageBlocked"]);
-		unset($deck["totalDamagePrevented"]);
-		unset($deck["totalLifeLost"]);
-		unset($deck["averageDamageThreatenedPerTurn"]);
-		unset($deck["averageDamageDealtPerTurn"]);
-		unset($deck["averageDamageThreatenedPerCard"]);
-		unset($deck["averageResourcesUsedPerTurn"]);
-		unset($deck["averageCardsLeftOverPerTurn"]);
-		unset($deck["averageCombatValuePerTurn"]);
-		unset($deck["averageValuePerTurn"]);
-		unset($deck["totalDamageThreatened_NoLast"]);
-		unset($deck["totalDamageDealt_NoLast"]);
-		unset($deck["totalLifeGained_NoLast"]);
-		unset($deck["totalDamageBlocked_NoLast"]);
-		unset($deck["totalDamagePrevented_NoLast"]);
-		unset($deck["totalLifeLost_NoLast"]);
-		unset($deck["averageDamageThreatenedPerTurn_NoLast"]);
-		unset($deck["averageDamageDealtPerTurn_NoLast"]);
-		unset($deck["averageDamageThreatenedPerCard_NoLast"]);
-		unset($deck["averageResourcesUsedPerTurn_NoLast"]);
-		unset($deck["averageCardsLeftOverPerTurn_NoLast"]);
-		unset($deck["averageCombatValuePerTurn_NoLast"]);
-		unset($deck["averageValuePerTurn_NoLast"]);
+		ExcludePrivateDetailedGameResultFields($deck);
 	}
 
 	return json_encode($deck);

--- a/tests/BusinessLogic/GameResultSerializationTest.php
+++ b/tests/BusinessLogic/GameResultSerializationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Talishar\Tests\BusinessLogic;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class GameResultSerializationTest extends TestCase
+{
+    public static function characterLines(): array
+    {
+        return [
+            'untransformed hero' => ['bravo_showstopper tunic_of_fyendal', 'bravo_showstopper'],
+            'transformed Arakni game' => ['arakni_marionette arakni_orb_weaver', 'arakni_marionette'],
+            'transformed Teklovossen game' => ['teklovossen_esteemed_magnate singularity_r', 'teklovossen_esteemed_magnate'],
+            'mixed whitespace' => [" \tviserai_the_forsaken   face_purgatory\n", 'viserai_the_forsaken'],
+            'missing character line' => ['', ''],
+            'whitespace-only character line' => [" \t\r\n", ''],
+        ];
+    }
+
+    #[DataProvider('characterLines')]
+    public function testExtractStartingHeroFromFirstSubmittedCharacter(string $line, string $expected): void
+    {
+        $this->assertSame($expected, ExtractStartingHeroFromCharacterLine($line));
+    }
+
+    public function testStartingHeroSurvivesPrivateTelemetryExclusion(): void
+    {
+        $deck = [
+            'character' => [['cardId' => 'levia_shadowborn_abomination']],
+            'cardResults' => [['cardId' => 'blood_debt_card']],
+            'deckbuilderID' => 'private-deck',
+        ];
+
+        AddStartingHeroToDetailedResult($deck, 'levia_shadowborn_abomination blasmophet_levia_consumed');
+        ExcludePrivateDetailedGameResultFields($deck);
+
+        $this->assertSame('levia_shadowborn_abomination', $deck['startingHero']);
+        $this->assertArrayNotHasKey('character', $deck);
+        $this->assertArrayNotHasKey('cardResults', $deck);
+        $this->assertArrayNotHasKey('deckbuilderID', $deck);
+    }
+
+    public function testMissingCharacterDoesNotEmitStartingHero(): void
+    {
+        $deck = [];
+        AddStartingHeroToDetailedResult($deck, " \t ");
+        $this->assertArrayNotHasKey('startingHero', $deck);
+    }
+}


### PR DESCRIPTION
## Summary

- Add an optional startingHero field to detailed FaB Insights game results.
- Derive it from the first submitted character entry, including whitespace-tolerant deck lines.
- Preserve it when private deck and card telemetry is excluded.
- Keep playerHero and opposingHero unchanged as end-of-game compatibility fields.

## Why

Hero transformations mutate the live character before game completion. Completed-game telemetry can therefore report a transformed form as playerHero, even though matchup reporting needs the hero that began the game. The submitted character line retains that starting identity.

## Impact and safety

This is an additive telemetry field. Existing consumers can continue using the current end-of-game fields, and consumers that ignore unknown properties remain compatible. The downstream FaB Insights CSV pass-through will be verified after deployment before Pitchstack enables the historical correction rollout.

## Validation

- PHP syntax checks passed on changed files.
- Focused serialization coverage passed: 8 tests and 11 assertions.
- Full PHPUnit suite passed: 181 tests and 888 assertions.
- The full suite still emits the repository existing warnings and deprecations.